### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/francisdb/pinmame-nvram/security/code-scanning/8](https://github.com/francisdb/pinmame-nvram/security/code-scanning/8)

To fix the problem, add a `permissions` block to the workflow, either at the root level or under the `build` job. Root-level is preferred if all jobs in the workflow need only minimal permissions, as in this case. Set permissions so only the least privilege required is granted – for this workflow, the only necessary permission is `contents: read`, to enable source code checkout. This change should be made by adding a `permissions:` block after the `name:` and before `env:`. No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
