### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,5 +1,7 @@
 on: push
 name: Clippy check
+permissions:
+  contents: read
 
 # Make sure CI fails on all warnings, including Clippy lints
 env:


### PR DESCRIPTION
Potential fix for [https://github.com/francisdb/pinmame-nvram/security/code-scanning/7](https://github.com/francisdb/pinmame-nvram/security/code-scanning/7)

To fix this issue, add a `permissions` key setting to the workflow. The best practice is to specify the minimal permission required to run the workflow successfully. For the shown workflow, which only reads repository contents and does not attempt to create issues, push changes, or create pull requests, the least privilege required is `contents: read`. Place this block at the workflow root, just below the workflow name (recommended), so it will apply to all jobs unless a specific job overrides it. No existing functionality will be changed, and no additional imports or changes outside the workflow file are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
