### PR TITLE
feat(resolve): expose units on resolved numeric values

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -72,6 +72,16 @@ fn resolve_recursive<T: Read + Seek, S: GlobalSettings>(
                     // maybe we should instead remove all properties related to the encoding
                     resolved_map.insert("label".to_string(), label.clone());
                 }
+                // Surface the map's unit annotation on resolved numeric fields
+                // so downstream consumers can render time-like / distance-like
+                // scores with the right formatting (e.g. `units: "seconds"`
+                // -> `mm:ss.dd`) without hardcoding per-table knowledge.
+                // `scale` is intentionally not propagated: `value` is already
+                // post-scaled, so exposing it would just invite double-scaling
+                // bugs. See issue #124.
+                if let Some(units) = map.get("units") {
+                    resolved_map.insert("units".to_string(), units.clone());
+                }
                 if let Some(warning) = warning {
                     resolved_map.insert("warning".to_string(), Value::String(warning));
                 }
@@ -427,6 +437,39 @@ mod tests {
 
         // let json = serde_json::to_string_pretty(&map.unwrap())?;
         // assert_eq!("{}", json);
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_propagates_units() -> io::Result<()> {
+        // Lord of the Rings has a Destroy Ring Champion score annotated as
+        // `units: "seconds"` in the map. We want it present on the resolved
+        // value so downstream consumers can render time-like scores as
+        // mm:ss.dd without per-table knowledge (see #124).
+        //
+        // `scale` is deliberately not propagated; `value` is already post-
+        // scaled by resolve_value, so exposing it would invite double-scaling
+        // bugs in callers.
+        let resolved = resolve(Path::new("testdata/lotr.nv"))?.expect("lotr.nv should resolve");
+        let drc = resolved
+            .get("mode_champions")
+            .and_then(|v| v.as_array())
+            .and_then(|a| {
+                a.iter().find(|e| {
+                    e.get("label") == Some(&Value::String("Destroy Ring Champion".to_string()))
+                })
+            })
+            .expect("Destroy Ring Champion entry");
+        let score = drc.get("score").expect("score object");
+        assert_eq!(
+            score.get("units").and_then(|v| v.as_str()),
+            Some("seconds"),
+            "units annotation should be on the resolved score"
+        );
+        assert!(
+            score.get("scale").is_none(),
+            "scale should NOT be propagated - value is already post-scaled"
+        );
         Ok(())
     }
 

--- a/testdata/afm_113.nv.json
+++ b/testdata/afm_113.nv.json
@@ -230,10 +230,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 290
       },
       "22": {
         "label": "Minutes On",
+        "units": "minutes",
         "value": 130
       },
       "23": {
@@ -282,6 +284,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/afm_113b-buyin.nv.json
+++ b/testdata/afm_113b-buyin.nv.json
@@ -230,10 +230,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 120
       },
       "22": {
         "label": "Minutes On",
+        "units": "minutes",
         "value": 19
       },
       "23": {
@@ -282,6 +284,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/afm_113b.nv.json
+++ b/testdata/afm_113b.nv.json
@@ -230,10 +230,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 120
       },
       "22": {
         "label": "Minutes On",
+        "units": "minutes",
         "value": 13
       },
       "23": {
@@ -282,6 +284,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/algar_l1.nv.json
+++ b/testdata/algar_l1.nv.json
@@ -154,6 +154,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/alpok_l6.nv.json
+++ b/testdata/alpok_l6.nv.json
@@ -154,6 +154,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/barra_l1.nv.json
+++ b/testdata/barra_l1.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/bk_l4.nv.json
+++ b/testdata/bk_l4.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/blkou_l1.nv.json
+++ b/testdata/blkou_l1.nv.json
@@ -138,6 +138,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/bop_l7.nv.json
+++ b/testdata/bop_l7.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 9
       },
       "23": {
@@ -150,6 +152,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/bop_l8.nv.json
+++ b/testdata/bop_l8.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 0
       },
       "23": {
@@ -150,6 +152,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/br_l4.nv.json
+++ b/testdata/br_l4.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 80
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/cc_13.nv.json
+++ b/testdata/cc_13.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/cftbl_l4.nv.json
+++ b/testdata/cftbl_l4.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/che_cho.nv.json
+++ b/testdata/che_cho.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "MINUTES OF PLAY",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 2
       },
       "23": {

--- a/testdata/comet_l5.nv.json
+++ b/testdata/comet_l5.nv.json
@@ -208,6 +208,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/congo_21.nv.json
+++ b/testdata/congo_21.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/corv_21.nv.json
+++ b/testdata/corv_21.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/cp_16.nv.json
+++ b/testdata/cp_16.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/csmic_l1.nv.json
+++ b/testdata/csmic_l1.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/cv_14.nv.json
+++ b/testdata/cv_14.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/cv_20h.nv.json
+++ b/testdata/cv_20h.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/dfndr_l4.nv.json
+++ b/testdata/dfndr_l4.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 5
       },
       "11": {

--- a/testdata/dh_lx2.nv.json
+++ b/testdata/dh_lx2.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/dm_h6.nv.json
+++ b/testdata/dm_h6.nv.json
@@ -332,10 +332,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "Machine On",
+        "units": "minutes",
         "value": 1
       },
       "23": {
@@ -384,6 +386,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/dm_lx4.nv.json
+++ b/testdata/dm_lx4.nv.json
@@ -328,10 +328,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 120
       },
       "22": {
         "label": "Machine On",
+        "units": "minutes",
         "value": 6
       },
       "23": {
@@ -380,6 +382,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/drac_l1.nv.json
+++ b/testdata/drac_l1.nv.json
@@ -396,6 +396,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 300
       },
       "22": {
@@ -448,6 +449,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/dw_l2.nv.json
+++ b/testdata/dw_l2.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 40
       },
       "22": {
         "label": "Machine On",
+        "units": "minutes",
         "value": 25
       },
       "23": {
@@ -150,6 +152,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/fh_905h.nv.json
+++ b/testdata/fh_905h.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 200
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 11
       },
       "23": {
@@ -150,6 +152,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/fh_906h.nv.json
+++ b/testdata/fh_906h.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 13000
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 682
       },
       "23": {
@@ -150,6 +152,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/fh_l9.nv.json
+++ b/testdata/fh_l9.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 1420
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 120
       },
       "23": {
@@ -150,6 +152,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/flash_l1.nv.json
+++ b/testdata/flash_l1.nv.json
@@ -143,6 +143,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/fpwr2_l2.nv.json
+++ b/testdata/fpwr2_l2.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/fs_lx5.nv.json
+++ b/testdata/fs_lx5.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/ft_l5.nv.json
+++ b/testdata/ft_l5.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 1890
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/gi_l9.nv.json
+++ b/testdata/gi_l9.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/grgar_l1.nv.json
+++ b/testdata/grgar_l1.nv.json
@@ -138,6 +138,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 1
       },
       "11": {

--- a/testdata/gw_l5.nv.json
+++ b/testdata/gw_l5.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/hd_l1.nv.json
+++ b/testdata/hd_l1.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "MINUTES OF PLAY",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 0
       },
       "23": {

--- a/testdata/hd_l3.nv.json
+++ b/testdata/hd_l3.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "MINUTES OF PLAY",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 0
       },
       "23": {

--- a/testdata/hurr_l2.nv.json
+++ b/testdata/hurr_l2.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "MINUTES OF PLAY",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 3
       },
       "23": {

--- a/testdata/hypbl_l6.nv.json
+++ b/testdata/hypbl_l6.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/i500_11r.nv.json
+++ b/testdata/i500_11r.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 40
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/ij_l7.nv.json
+++ b/testdata/ij_l7.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 150
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/jb_10r.nv.json
+++ b/testdata/jb_10r.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/jd_l1.nv.json
+++ b/testdata/jd_l1.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 2
       },
       "23": {
@@ -150,6 +152,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/jd_l7.nv.json
+++ b/testdata/jd_l7.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 1
       },
       "23": {
@@ -150,6 +152,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/jm_12r.nv.json
+++ b/testdata/jm_12r.nv.json
@@ -308,10 +308,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "Machine On",
+        "units": "minutes",
         "value": 41
       },
       "23": {
@@ -360,6 +362,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/jngld_l2.nv.json
+++ b/testdata/jngld_l2.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/jst_l2.nv.json
+++ b/testdata/jst_l2.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/jy_12.nv.json
+++ b/testdata/jy_12.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/lotr.nv.json
+++ b/testdata/lotr.nv.json
@@ -111,6 +111,7 @@
       },
       "label": "Destroy Ring Champion",
       "score": {
+        "units": "seconds",
         "value": 600
       }
     }

--- a/testdata/lsrcu_l2.nv.json
+++ b/testdata/lsrcu_l2.nv.json
@@ -17,6 +17,7 @@
       },
       "33": {
         "label": "Extra Ball Time",
+        "units": "seconds",
         "value": 10
       },
       "34": {
@@ -181,6 +182,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/lzbal_l2.nv.json
+++ b/testdata/lzbal_l2.nv.json
@@ -138,6 +138,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/mb_10.nv.json
+++ b/testdata/mb_10.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/mb_106.nv.json
+++ b/testdata/mb_106.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/mb_106b.nv.json
+++ b/testdata/mb_106b.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 30
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/mm_10.nv.json
+++ b/testdata/mm_10.nv.json
@@ -94,10 +94,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "Minutes On",
+        "units": "minutes",
         "value": 0
       },
       "23": {
@@ -146,6 +148,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/mm_109.nv.json
+++ b/testdata/mm_109.nv.json
@@ -94,10 +94,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "Minutes On",
+        "units": "minutes",
         "value": 1
       },
       "23": {
@@ -146,6 +148,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/mm_109b.nv.json
+++ b/testdata/mm_109b.nv.json
@@ -94,10 +94,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "Minutes On",
+        "units": "minutes",
         "value": 1
       },
       "23": {
@@ -146,6 +148,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/mm_109c.nv.json
+++ b/testdata/mm_109c.nv.json
@@ -94,10 +94,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 130
       },
       "22": {
         "label": "Minutes On",
+        "units": "minutes",
         "value": 10
       },
       "23": {
@@ -146,6 +148,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/nbaf_31.nv.json
+++ b/testdata/nbaf_31.nv.json
@@ -234,6 +234,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -286,6 +287,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/nf_23x.nv.json
+++ b/testdata/nf_23x.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/ngg_13.nv.json
+++ b/testdata/ngg_13.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/pharo_l2.nv.json
+++ b/testdata/pharo_l2.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/pop_lx5.nv.json
+++ b/testdata/pop_lx5.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/pz_f4.nv.json
+++ b/testdata/pz_f4.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "MINUTES OF PLAY",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 2
       },
       "23": {

--- a/testdata/pz_l3.nv.json
+++ b/testdata/pz_l3.nv.json
@@ -98,10 +98,12 @@
       },
       "21": {
         "label": "MINUTES OF PLAY",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "MINUTES ON",
+        "units": "minutes",
         "value": 0
       },
       "23": {

--- a/testdata/ratrc_l1.nv.json
+++ b/testdata/ratrc_l1.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/rs_l6.nv.json
+++ b/testdata/rs_l6.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 70
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/sc_091.nv.json
+++ b/testdata/sc_091.nv.json
@@ -86,6 +86,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 10
       },
       "22": {
@@ -126,6 +127,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/sc_18s11.nv.json
+++ b/testdata/sc_18s11.nv.json
@@ -86,6 +86,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 120
       },
       "22": {
@@ -126,6 +127,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/sc_18s2.nv.json
+++ b/testdata/sc_18s2.nv.json
@@ -86,6 +86,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -126,6 +127,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/scrpn_l1.nv.json
+++ b/testdata/scrpn_l1.nv.json
@@ -138,6 +138,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/solar_l2.nv.json
+++ b/testdata/solar_l2.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/sorcr_l1.nv.json
+++ b/testdata/sorcr_l1.nv.json
@@ -208,6 +208,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/sorcr_l2.nv.json
+++ b/testdata/sorcr_l2.nv.json
@@ -208,6 +208,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 1
       },
       "11": {

--- a/testdata/ss_15.nv.json
+++ b/testdata/ss_15.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 70
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/sshtl_l7.nv.json
+++ b/testdata/sshtl_l7.nv.json
@@ -208,6 +208,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/stlwr_l2.nv.json
+++ b/testdata/stlwr_l2.nv.json
@@ -134,6 +134,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/strlt_l1.nv.json
+++ b/testdata/strlt_l1.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/sttng_l7.nv.json
+++ b/testdata/sttng_l7.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/t2_l8.nv.json
+++ b/testdata/t2_l8.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 110
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/taf_h4.nv.json
+++ b/testdata/taf_h4.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/taf_l5.nv.json
+++ b/testdata/taf_l5.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/taf_l6.nv.json
+++ b/testdata/taf_l6.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/taf_l7.nv.json
+++ b/testdata/taf_l7.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 120
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/tafg_lx3.nv.json
+++ b/testdata/tafg_lx3.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 340
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/thund_p2.nv.json
+++ b/testdata/thund_p2.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/thund_p3.nv.json
+++ b/testdata/thund_p3.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/tmfnt_l5.nv.json
+++ b/testdata/tmfnt_l5.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/tmwrp_l2.nv.json
+++ b/testdata/tmwrp_l2.nv.json
@@ -138,6 +138,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/tom_13.nv.json
+++ b/testdata/tom_13.nv.json
@@ -316,10 +316,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 550
       },
       "22": {
         "label": "Machine On",
+        "units": "minutes",
         "value": 45
       },
       "23": {
@@ -368,6 +370,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/tom_14h.nv.json
+++ b/testdata/tom_14h.nv.json
@@ -316,10 +316,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "Machine On",
+        "units": "minutes",
         "value": 1
       },
       "23": {
@@ -368,6 +370,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/tom_14hb.nv.json
+++ b/testdata/tom_14hb.nv.json
@@ -316,10 +316,12 @@
       },
       "21": {
         "label": "Play Time",
+        "units": "seconds",
         "value": 0
       },
       "22": {
         "label": "Machine On",
+        "units": "minutes",
         "value": 2
       },
       "23": {
@@ -368,6 +370,7 @@
       },
       "34": {
         "label": "Burn-in Time",
+        "units": "seconds",
         "value": 0
       },
       "35": {

--- a/testdata/totan_14.nv.json
+++ b/testdata/totan_14.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 140
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/trizn_l1.nv.json
+++ b/testdata/trizn_l1.nv.json
@@ -138,6 +138,7 @@
       },
       "10": {
         "label": "Total Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/ts_lx5.nv.json
+++ b/testdata/ts_lx5.nv.json
@@ -94,6 +94,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 250
       },
       "22": {
@@ -146,6 +147,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/tz_92.nv.json
+++ b/testdata/tz_92.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/tz_94ch.nv.json
+++ b/testdata/tz_94ch.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/tz_94h.nv.json
+++ b/testdata/tz_94h.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 300
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/vrkon_l1.nv.json
+++ b/testdata/vrkon_l1.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/wcs_l2.nv.json
+++ b/testdata/wcs_l2.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/wd_12.nv.json
+++ b/testdata/wd_12.nv.json
@@ -94,6 +94,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 240
       },
       "22": {
@@ -146,6 +147,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/wd_12g.nv.json
+++ b/testdata/wd_12g.nv.json
@@ -94,6 +94,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -146,6 +147,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/wd_12gp.nv.json
+++ b/testdata/wd_12gp.nv.json
@@ -94,6 +94,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -146,6 +147,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/wd_12p.nv.json
+++ b/testdata/wd_12p.nv.json
@@ -94,6 +94,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -146,6 +147,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/wrlok_l3-default.nv.json
+++ b/testdata/wrlok_l3-default.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 0
       },
       "11": {

--- a/testdata/wrlok_l3.nv.json
+++ b/testdata/wrlok_l3.nv.json
@@ -200,6 +200,7 @@
       },
       "10": {
         "label": "Ball Time",
+        "units": "minutes",
         "value": 2
       },
       "11": {

--- a/testdata/ww_l5.nv.json
+++ b/testdata/ww_l5.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 180
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/ww_lh6-default.nv.json
+++ b/testdata/ww_lh6-default.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 0
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {

--- a/testdata/ww_lh6.nv.json
+++ b/testdata/ww_lh6.nv.json
@@ -98,6 +98,7 @@
       },
       "21": {
         "label": "PLAY TIME",
+        "units": "seconds",
         "value": 70
       },
       "22": {
@@ -150,6 +151,7 @@
       },
       "34": {
         "label": "BURN-IN TIME",
+        "units": "seconds",
         "value": 0
       },
       "36": {


### PR DESCRIPTION
Closes #124.

`resolve()` now propagates the map's `units` annotation onto the resolved `Value` alongside `value` and `label`. Backward-compatible: consumers that only read `value`/`label` are unaffected.

LotR's Destroy Ring Champion was:
```json
{ "label": "Destroy Ring Champion", "score": { "value": 600 } }
```
now is:
```json
{ "label": "Destroy Ring Champion", "score": { "value": 600, "units": "seconds" } }
```

Downstream consumers ([vpxtool#779](https://github.com/francisdb/vpxtool/pull/779)) can now render \`units: "seconds"\` as \`mm:ss.dd\` without per-table code.

`scale` is intentionally NOT propagated: \`value\` is already post-scaled inside \`resolve_value\` (via \`apply_scale\`), so exposing scale would just invite double-scaling bugs in callers.

## Test plan

- [x] New unit test \`test_resolve_propagates_units\` against \`lotr.nv\` - asserts \`units\` propagates and \`scale\` does not.
- [x] All snapshot files under \`testdata/\` regenerated; diff is purely additive (only \`+\` lines, no \`-\`). Two distinct units appear in the current maps: \`seconds\` and \`minutes\`.
- [x] \`cargo test\` clean (39 pass).
- [x] \`cargo clippy --all-targets\` and \`cargo fmt\` clean.