### PR TITLE
feat(encoding): support scattered offsets for int and ch encodings

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -8,6 +8,31 @@ pub(crate) enum Location {
     Scattered { offsets: Vec<u64> },
 }
 
+/// Read the raw bytes for a location into a buffer.
+///
+/// A `Continuous` location reads `length` consecutive bytes from `start`.
+/// A `Scattered` location reads a single byte from each offset, in order. This
+/// is used by platforms like Capcom where the 8-bit NVRAM is mapped on a 16-bit
+/// bus, so the bytes that make up a value live at non-consecutive file offsets.
+fn read_location<A: Read + Seek>(stream: &mut A, location: &Location) -> io::Result<Vec<u8>> {
+    match location {
+        Location::Continuous { start, length } => {
+            let mut buff = vec![0; *length];
+            read_exact_at(stream, *start, &mut buff)?;
+            Ok(buff)
+        }
+        Location::Scattered { offsets } => {
+            let mut buff = Vec::with_capacity(offsets.len());
+            for offset in offsets {
+                let mut byte = [0; 1];
+                read_exact_at(stream, *offset, &mut byte)?;
+                buff.push(byte[0]);
+            }
+            Ok(buff)
+        }
+    }
+}
+
 pub(crate) fn de_nibble(length: usize, buff: &[u8], nibble: Nibble) -> io::Result<Vec<u8>> {
     if nibble == Nibble::Both {
         return Ok(buff.to_vec());
@@ -85,15 +110,14 @@ pub(crate) fn do_nibble(length: usize, buff: &[u8], nibble: Nibble) -> io::Resul
 
 pub(crate) fn read_ch<A: Read + Seek>(
     stream: &mut A,
-    location: u64,
-    length: usize,
+    location: Location,
     mask: Option<u64>,
     char_map: &Option<String>,
     nibble: Nibble,
     null: Option<Null>,
 ) -> io::Result<String> {
-    let mut buff = vec![0; length];
-    read_exact_at(stream, location, &mut buff)?;
+    let mut buff = read_location(stream, &location)?;
+    let length = buff.len();
 
     if nibble != Nibble::Both {
         let result = de_nibble(length, &buff, nibble)?;
@@ -195,22 +219,7 @@ pub(crate) fn read_bcd<A: Read + Seek>(
     scale: &Number,
     endian: Endian,
 ) -> io::Result<u64> {
-    let mut buff = match location {
-        Location::Continuous { start, length } => {
-            let mut buff = vec![0; length];
-            read_exact_at(stream, start, &mut buff)?;
-            buff
-        }
-        Location::Scattered { offsets } => {
-            let mut buff = vec![0; offsets.len()];
-            for offset in offsets.iter() {
-                let mut byte = [0; 1];
-                read_exact_at(stream, *offset, &mut byte)?;
-                buff.push(byte[0]);
-            }
-            buff
-        }
-    };
+    let mut buff = read_location(stream, &location)?;
 
     if endian == Endian::Little {
         buff.reverse();
@@ -275,14 +284,11 @@ pub(crate) fn read_int<T: Read + Seek>(
     nvram_file: &mut T,
     endian: Endian,
     nibble: Nibble,
-    start: u64,
-    length: usize,
+    location: Location,
     scale: &Number,
 ) -> io::Result<u64> {
-    nvram_file.seek(SeekFrom::Start(start))?;
-    let mut buff = vec![0; length];
-    read_exact_at(nvram_file, start, &mut buff)?;
-    buff = de_nibble(length, &buff, nibble)?;
+    let buff = read_location(nvram_file, &location)?;
+    let buff = de_nibble(buff.len(), &buff, nibble)?;
     let score = match endian {
         Endian::Big => buff
             .iter()
@@ -355,8 +361,7 @@ pub(crate) fn read_bool<T: Read + Seek>(
         nvram_file,
         endian,
         nibble,
-        start,
-        length,
+        Location::Continuous { start, length },
         &Number::from(DEFAULT_SCALE),
     )?;
     let bool_value = if invert { value == 0 } else { value != 0 };
@@ -413,8 +418,10 @@ mod tests {
             &mut cursor,
             Endian::Little,
             Nibble::Both,
-            1,
-            1,
+            Location::Continuous {
+                start: 1,
+                length: 1,
+            },
             &Number::from(DEFAULT_SCALE),
         )?;
         pretty_assertions::assert_eq!(value, 255);
@@ -429,8 +436,10 @@ mod tests {
             &mut cursor,
             Endian::Little,
             Nibble::High,
-            1,
-            1,
+            Location::Continuous {
+                start: 1,
+                length: 1,
+            },
             &Number::from(DEFAULT_SCALE),
         )?;
         pretty_assertions::assert_eq!(value, 15);
@@ -440,7 +449,17 @@ mod tests {
     #[test]
     fn test_read_ch() -> io::Result<()> {
         let mut cursor = io::Cursor::new(vec![0x41, 0x42, 0x43, 0x44, 0x45]);
-        let score = read_ch(&mut cursor, 0x0000, 5, None, &None, Nibble::Both, None)?;
+        let score = read_ch(
+            &mut cursor,
+            Location::Continuous {
+                start: 0x0000,
+                length: 5,
+            },
+            None,
+            &None,
+            Nibble::Both,
+            None,
+        )?;
         pretty_assertions::assert_eq!(score, "ABCDE");
         Ok(())
     }
@@ -449,7 +468,17 @@ mod tests {
     fn test_read_ch_with_charmap() -> io::Result<()> {
         let char_map = Some("???????????ABCDEFGHIJKLMNOPQRSTUVWXYZ".to_string());
         let mut cursor = io::Cursor::new(vec![0x0B, 0x0C, 0x0D, 0x0E, 0x0F]);
-        let score = read_ch(&mut cursor, 0x0000, 5, None, &char_map, Nibble::Both, None)?;
+        let score = read_ch(
+            &mut cursor,
+            Location::Continuous {
+                start: 0x0000,
+                length: 5,
+            },
+            None,
+            &char_map,
+            Nibble::Both,
+            None,
+        )?;
         pretty_assertions::assert_eq!(score, "ABCDE");
         Ok(())
     }
@@ -483,7 +512,17 @@ mod tests {
         // Nibble: where the sequence 0x04 0x01 0x04 0x02 0x04 0x03
         // translates to 0x41 0x42 0x43 which is the string "ABC"
         let mut cursor = io::Cursor::new(vec![0x04, 0x01, 0x04, 0x02, 0x04, 0x03]);
-        let score = read_ch(&mut cursor, 0x0000, 6, None, &None, Nibble::Low, None)?;
+        let score = read_ch(
+            &mut cursor,
+            Location::Continuous {
+                start: 0x0000,
+                length: 6,
+            },
+            None,
+            &None,
+            Nibble::Low,
+            None,
+        )?;
         pretty_assertions::assert_eq!(score, "ABC");
         Ok(())
     }
@@ -493,8 +532,10 @@ mod tests {
         let mut cursor = io::Cursor::new(vec![0x41, 0x42, 0x43, 0x00, 0xFF]);
         let score = read_ch(
             &mut cursor,
-            0x0000,
-            5,
+            Location::Continuous {
+                start: 0x0000,
+                length: 5,
+            },
             None,
             &None,
             Nibble::Both,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,19 +452,12 @@ fn read_highscore<T: Read + Seek, S: GlobalSettings>(
 ) -> io::Result<HighScore> {
     let mut initials = "".to_string();
     if let Some(map_initials) = &hs.initials {
-        initials = read_ch(
+        initials = read_ch_descriptor(
             &mut nvram_file,
-            u64::from(
-                map_initials
-                    .start
-                    .as_ref()
-                    .expect("missing start for ch encoding"),
-            ) - offset,
-            map_initials.length.expect("missing length for ch encoding"),
-            map_initials.mask.as_ref().map(|m| m.into()),
-            global_settings.char_map(),
-            map_initials.nibble.unwrap_or(nibble),
-            map_initials.null,
+            map_initials,
+            nibble,
+            offset,
+            global_settings,
         )?;
     }
 
@@ -525,20 +518,7 @@ fn read_mode_champion<T: Read + Seek, S: GlobalSettings>(
         .initials
         .as_ref()
         .map(|initials| {
-            read_ch(
-                &mut nvram_file,
-                u64::from(
-                    initials
-                        .start
-                        .as_ref()
-                        .expect("missing start for ch encoding"),
-                ) - offset,
-                initials.length.expect("missing start for ch encoding"),
-                initials.mask.as_ref().map(|m| m.into()),
-                global_settings.char_map(),
-                initials.nibble.unwrap_or(nibble),
-                initials.null,
-            )
+            read_ch_descriptor(&mut nvram_file, initials, nibble, offset, global_settings)
         })
         .transpose()?;
     let score = if let Some(score) = &mc.score {
@@ -727,45 +707,28 @@ fn read_descriptor_to_string<T: Read + Seek, S: GlobalSettings>(
     global_settings: &S,
 ) -> io::Result<String> {
     match descriptor.encoding {
-        Encoding::Ch => match &descriptor.start {
-            Some(start) => read_ch(
-                &mut nvram_file,
-                u64::from(start) - offset,
-                descriptor.length.unwrap_or(DEFAULT_LENGTH),
-                descriptor.mask.as_ref().map(|m| m.into()),
-                global_settings.char_map(),
-                descriptor.nibble.unwrap_or(nibble),
-                None,
-            ),
-            None => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Ch descriptor requires start",
-            )),
-        },
-        Encoding::Int => match &descriptor.start {
-            Some(start) => {
-                let start = u64::from(start);
-                if start < offset {
+        Encoding::Ch => {
+            read_ch_descriptor(&mut nvram_file, descriptor, nibble, offset, global_settings)
+        }
+        Encoding::Int => {
+            let location = match location_for(descriptor, offset)? {
+                LocateResult::OutsideNVRAM => {
                     return Ok("Value is stored outside the NVRAM".to_string());
                 }
-                let score = read_int(
-                    &mut nvram_file,
-                    endian,
-                    nibble,
-                    start - offset,
-                    descriptor.length.unwrap_or(DEFAULT_LENGTH),
-                    descriptor
-                        .scale
-                        .as_ref()
-                        .unwrap_or(&Number::from(DEFAULT_SCALE)),
-                )?;
-                Ok(score.to_string())
-            }
-            None => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Int descriptor requires start",
-            )),
-        },
+                LocateResult::Located(loc) => loc,
+            };
+            let score = read_int(
+                &mut nvram_file,
+                endian,
+                nibble,
+                location,
+                descriptor
+                    .scale
+                    .as_ref()
+                    .unwrap_or(&Number::from(DEFAULT_SCALE)),
+            )?;
+            Ok(score.to_string())
+        }
         Encoding::Bcd => {
             let location = match location_for(descriptor, offset)? {
                 LocateResult::OutsideNVRAM => {
@@ -842,24 +805,28 @@ fn read_descriptor_to_u64<T: Read + Seek>(
             )
         }
         Encoding::Int => {
-            if let Some(start) = &descriptor.start {
-                read_int(
-                    &mut nvram_file,
-                    endian,
-                    descriptor.nibble.unwrap_or(nibble),
-                    u64::from(start) - offset,
-                    descriptor.length.unwrap_or(DEFAULT_LENGTH),
-                    descriptor
-                        .scale
-                        .as_ref()
-                        .unwrap_or(&Number::from(DEFAULT_SCALE)),
-                )
-            } else {
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "Int descriptor requires start",
-                ))
-            }
+            let location = match location_for(descriptor, offset)? {
+                LocateResult::OutsideNVRAM => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "Descriptor '{}' points outside NVRAM",
+                            descriptor.label.as_deref().unwrap_or("unknown")
+                        ),
+                    ));
+                }
+                LocateResult::Located(loc) => loc,
+            };
+            read_int(
+                &mut nvram_file,
+                endian,
+                descriptor.nibble.unwrap_or(nibble),
+                location,
+                descriptor
+                    .scale
+                    .as_ref()
+                    .unwrap_or(&Number::from(DEFAULT_SCALE)),
+            )
         }
         other => todo!("Encoding not implemented: {:?}", other),
     }
@@ -885,6 +852,33 @@ fn read_descriptor_to_rtc_string<T: Read + Seek>(
 enum LocateResult {
     OutsideNVRAM,
     Located(Location),
+}
+
+/// Read a `ch` (character) descriptor, supporting both `start` and `offsets`.
+fn read_ch_descriptor<T: Read + Seek, S: GlobalSettings>(
+    nvram_file: &mut T,
+    descriptor: &Descriptor,
+    nibble: Nibble,
+    offset: u64,
+    global_settings: &S,
+) -> io::Result<String> {
+    let location = match location_for(descriptor, offset)? {
+        LocateResult::OutsideNVRAM => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Value is stored outside the NVRAM",
+            ));
+        }
+        LocateResult::Located(loc) => loc,
+    };
+    read_ch(
+        nvram_file,
+        location,
+        descriptor.mask.as_ref().map(|m| m.into()),
+        global_settings.char_map(),
+        descriptor.nibble.unwrap_or(nibble),
+        descriptor.null,
+    )
 }
 
 fn location_for(descriptor: &Descriptor, offset: u64) -> io::Result<LocateResult> {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -233,20 +233,14 @@ fn resolve_value<T: Read + Seek, U: GlobalSettings>(
                 .and_then(|s| s.as_number())
                 .cloned()
                 .unwrap_or(Number::from(DEFAULT_SCALE));
-            let start = start_in_nvram_file(nvram_layout, descriptor)?;
-            let value = read_int(rom, endian, nibble, start, length, &scale)?;
+            let location = location_in_nvram_file(nvram_layout, descriptor, length)?;
+            let value = read_int(rom, endian, nibble, location, &scale)?;
             Value::Number(value.into())
         }
         Encoding::Enum => {
-            let start = start_in_nvram_file(nvram_layout, descriptor)?;
-            let index = read_int(
-                rom,
-                endian,
-                nibble,
-                start,
-                length,
-                &Number::from(DEFAULT_SCALE),
-            )? as usize;
+            let location = location_in_nvram_file(nvram_layout, descriptor, length)?;
+            let index =
+                read_int(rom, endian, nibble, location, &Number::from(DEFAULT_SCALE))? as usize;
             let values = descriptor.get("values").unwrap().as_array().unwrap();
             let enum_value = values.get(index);
             return if let Some(enum_value) = enum_value {
@@ -263,21 +257,7 @@ fn resolve_value<T: Read + Seek, U: GlobalSettings>(
             };
         }
         Encoding::Bcd => {
-            let location = match descriptor.get("offsets") {
-                None => {
-                    let start = start_in_nvram_file(nvram_layout, descriptor)?;
-                    Location::Continuous { start, length }
-                }
-                Some(offsets) => {
-                    let offsets: Vec<u64> = offsets
-                        .as_array()
-                        .unwrap()
-                        .iter()
-                        .map(json_hex_or_int)
-                        .collect::<Result<Vec<_>, _>>()?;
-                    Location::Scattered { offsets }
-                }
-            };
+            let location = location_in_nvram_file(nvram_layout, descriptor, length)?;
             let scale = descriptor
                 .get("scale")
                 .and_then(|s| s.as_number())
@@ -293,7 +273,7 @@ fn resolve_value<T: Read + Seek, U: GlobalSettings>(
             Value::Number(value.into())
         }
         Encoding::Ch => {
-            let start = start_in_nvram_file(nvram_layout, descriptor)?;
+            let location = location_in_nvram_file(nvram_layout, descriptor, length)?;
             let mask = descriptor.get("mask").map(json_hex_or_int).transpose()?;
             let nibble = descriptor
                 .get("nibble")
@@ -304,8 +284,7 @@ fn resolve_value<T: Read + Seek, U: GlobalSettings>(
                 .map(|n| serde_json::from_value(n.clone()).unwrap());
             let value = read_ch(
                 rom,
-                start,
-                length,
+                location,
                 mask,
                 global_settings.char_map(),
                 nibble,
@@ -377,6 +356,46 @@ fn resolve_value<T: Read + Seek, U: GlobalSettings>(
         }
     };
     Ok(value)
+}
+
+/// Resolve the location of a value in the NVRAM file from a descriptor.
+///
+/// A descriptor either has a single `start` address (a contiguous run of
+/// `length` bytes) or an `offsets` array listing the address of each byte
+/// (used by platforms that map 8-bit NVRAM on a wider bus, so the bytes are
+/// not adjacent in the file). Both forms are CPU addresses and are translated
+/// to file offsets by subtracting the NVRAM layout base address.
+fn location_in_nvram_file(
+    nvram_layout: &MemoryLayout,
+    descriptor: &Map<String, Value>,
+    length: usize,
+) -> io::Result<Location> {
+    match descriptor.get("offsets") {
+        Some(offsets) => {
+            let base: u64 = (&nvram_layout.address).into();
+            let offsets = offsets
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|o| {
+                    let address = json_hex_or_int(o)?;
+                    if address < base {
+                        Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Value is stored outside the NVRAM",
+                        ))
+                    } else {
+                        Ok(address - base)
+                    }
+                })
+                .collect::<io::Result<Vec<u64>>>()?;
+            Ok(Location::Scattered { offsets })
+        }
+        None => {
+            let start = start_in_nvram_file(nvram_layout, descriptor)?;
+            Ok(Location::Continuous { start, length })
+        }
+    }
 }
 
 fn start_in_nvram_file(

--- a/testdata/abv106.nv.json
+++ b/testdata/abv106.nv.json
@@ -3,51 +3,51 @@
   "high_scores": [
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "DAM"
       },
       "label": "High Score #1",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 500000000
       },
       "short_label": "HS1"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "KEV"
       },
       "label": "High Score #2",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 412500000
       },
       "short_label": "HS2"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "BRI"
       },
       "label": "High Score #3",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 325000000
       },
       "short_label": "HS3"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "CG "
       },
       "label": "High Score #4",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 237500000
       },
       "short_label": "HS4"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "RLR"
       },
       "label": "High Score #5",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 150000000
       },
       "short_label": "HS5"
     }
@@ -55,51 +55,51 @@
   "mode_champions": [
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "SAM"
       },
       "label": "Buyin Boss #1",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 1000000000
       },
       "short_label": "BB1"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "KAT"
       },
       "label": "Buyin Boss #2",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 825000000
       },
       "short_label": "BB2"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "TND"
       },
       "label": "Buyin Boss #3",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 650000000
       },
       "short_label": "BB3"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "FML"
       },
       "label": "Buyin Boss #4",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 475000000
       },
       "short_label": "BB4"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "HUG"
       },
       "label": "Buyin Boss #5",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 300000000
       },
       "short_label": "BB5"
     }

--- a/testdata/bsv103.nv.json
+++ b/testdata/bsv103.nv.json
@@ -3,51 +3,51 @@
   "high_scores": [
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "WIZ"
       },
       "label": "High Score #1",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 10000000
       },
       "short_label": "HS1"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "TON"
       },
       "label": "High Score #2",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 8000000
       },
       "short_label": "HS2"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "DMW"
       },
       "label": "High Score #3",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 5000000
       },
       "short_label": "HS3"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "SOM"
       },
       "label": "High Score #4",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 4980340
       },
       "short_label": "HS4"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "SOM"
       },
       "label": "High Score #5",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 4081950
       },
       "short_label": "HS5"
     }
@@ -55,51 +55,51 @@
   "mode_champions": [
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "TND"
       },
       "label": "Buyin Boss #1",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 20000000
       },
       "short_label": "BB1"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "SAM"
       },
       "label": "Buyin Boss #2",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 16000000
       },
       "short_label": "BB2"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "PFZ"
       },
       "label": "Buyin Boss #3",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 10000000
       },
       "short_label": "BB3"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "DAN"
       },
       "label": "Buyin Boss #4",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 6000000
       },
       "short_label": "BB4"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "XXX"
       },
       "label": "Buyin Boss #5",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 2000000
       },
       "short_label": "BB5"
     }

--- a/testdata/kpb105.nv.json
+++ b/testdata/kpb105.nv.json
@@ -3,51 +3,51 @@
   "high_scores": [
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "MRP"
       },
       "label": "Kingpin #1",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 2500000000
       },
       "short_label": "KP1"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "TON"
       },
       "label": "Kingpin #2",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 2000000000
       },
       "short_label": "KP2"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "DMW"
       },
       "label": "Kingpin #3",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 1500000000
       },
       "short_label": "KP3"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "JRP"
       },
       "label": "Kingpin #4",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 1000000000
       },
       "short_label": "KP4"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "DMP"
       },
       "label": "Kingpin #5",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 500000000
       },
       "short_label": "KP5"
     }
@@ -55,51 +55,51 @@
   "mode_champions": [
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "TND"
       },
       "label": "Buyin Boss #1",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 5000000000
       },
       "short_label": "BB1"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "ASK"
       },
       "label": "Buyin Boss #2",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 4000000000
       },
       "short_label": "BB2"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "HOT"
       },
       "label": "Buyin Boss #3",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 3000000000
       },
       "short_label": "BB3"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "PFZ"
       },
       "label": "Buyin Boss #4",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 2000000000
       },
       "short_label": "BB4"
     },
     {
       "initials": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": "XXX"
       },
       "label": "Buyin Boss #5",
       "score": {
-        "warning": "Failed to resolve: Missing start value for NVRAM encoding"
+        "value": 1000000000
       },
       "short_label": "BB5"
     }


### PR DESCRIPTION
The scattered `offsets` form (a list of byte addresses, used by platforms that map 8-bit NVRAM on a wider bus so a value's bytes are not adjacent in the file) was only implemented for the `bcd` encoding. `int` and `ch` descriptors that used `offsets` instead of `start` failed with "Missing start value for NVRAM encoding". This matches the reference py-pinmame-nvmaps parser, where `offsets` is a first-class descriptor field for any encoding.

Resolves Capcom high scores and mode champions that previously produced warnings (e.g. abv106, bsv103, kpb105).