### PR TITLE
fix(encoding): support scattered offsets for bool encoding

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -351,17 +351,16 @@ pub(crate) fn read_wpc_rtc<T: Read + Seek>(
 
 pub(crate) fn read_bool<T: Read + Seek>(
     nvram_file: &mut T,
-    start: u64,
     nibble: Nibble,
     endian: Endian,
-    length: usize,
+    location: Location,
     invert: bool,
 ) -> io::Result<bool> {
     let value = read_int(
         nvram_file,
         endian,
         nibble,
-        Location::Continuous { start, length },
+        location,
         &Number::from(DEFAULT_SCALE),
     )?;
     let bool_value = if invert { value == 0 } else { value != 0 };
@@ -443,6 +442,53 @@ mod tests {
             &Number::from(DEFAULT_SCALE),
         )?;
         pretty_assertions::assert_eq!(value, 15);
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_bool_continuous() -> io::Result<()> {
+        let mut cursor = io::Cursor::new(vec![0x00, 0x01]);
+        let value = read_bool(
+            &mut cursor,
+            Nibble::Both,
+            Endian::Big,
+            Location::Continuous {
+                start: 1,
+                length: 1,
+            },
+            false,
+        )?;
+        pretty_assertions::assert_eq!(value, true);
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_bool_scattered() -> io::Result<()> {
+        // bool stored as a single byte at a scattered offset (Capcom 16-bit bus)
+        let mut cursor = io::Cursor::new(vec![0x00, 0x00, 0x01, 0x00]);
+        let value = read_bool(
+            &mut cursor,
+            Nibble::Both,
+            Endian::Big,
+            Location::Scattered { offsets: vec![2] },
+            false,
+        )?;
+        pretty_assertions::assert_eq!(value, true);
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_bool_scattered_invert() -> io::Result<()> {
+        // invert: a zero byte reads as true (used by "game_over" style flags)
+        let mut cursor = io::Cursor::new(vec![0x00, 0x00, 0x01, 0x00]);
+        let value = read_bool(
+            &mut cursor,
+            Nibble::Both,
+            Endian::Big,
+            Location::Scattered { offsets: vec![3] },
+            true,
+        )?;
+        pretty_assertions::assert_eq!(value, true);
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,24 +749,22 @@ fn read_descriptor_to_string<T: Read + Seek, S: GlobalSettings>(
             Ok(score.to_string())
         }
         Encoding::Bits => Ok("Bits encoding not implemented".to_string()),
-        Encoding::Bool => match &descriptor.start {
-            Some(start) => {
-                println!("Reading bool at start {:?}", start);
-                let bool = read_bool(
-                    nvram_file,
-                    u64::from(start) - offset,
-                    nibble,
-                    endian,
-                    descriptor.length.unwrap_or(DEFAULT_LENGTH),
-                    descriptor.invert.unwrap_or(DEFAULT_INVERT),
-                )?;
-                Ok(bool.to_string())
-            }
-            None => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Bool descriptor requires start",
-            )),
-        },
+        Encoding::Bool => {
+            let location = match location_for(descriptor, offset)? {
+                LocateResult::OutsideNVRAM => {
+                    return Ok("Value is stored outside the NVRAM".to_string());
+                }
+                LocateResult::Located(loc) => loc,
+            };
+            let bool = read_bool(
+                nvram_file,
+                nibble,
+                endian,
+                location,
+                descriptor.invert.unwrap_or(DEFAULT_INVERT),
+            )?;
+            Ok(bool.to_string())
+        }
         Encoding::Dipsw => Ok("Dipsw encoding not implemented".to_string()),
         other => todo!("Encoding not implemented: {:?}", other),
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -346,12 +346,12 @@ fn resolve_value<T: Read + Seek, U: GlobalSettings>(
             }
         }
         Encoding::Bool => {
-            let start = crate::resolve::start_in_nvram_file(nvram_layout, descriptor)?;
+            let location = location_in_nvram_file(nvram_layout, descriptor, length)?;
             let invert = descriptor
                 .get("invert")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(DEFAULT_INVERT);
-            let bool_value = read_bool(rom, start, nibble, endian, length, invert)?;
+            let bool_value = read_bool(rom, nibble, endian, location, invert)?;
             Value::Bool(bool_value)
         }
     };


### PR DESCRIPTION
The scattered offsets form (a list of byte addresses, used by platforms that map 8-bit NVRAM on a wider bus) was extended to int and ch in #128 but bool was missed. bool descriptors using offsets instead of start failed with "Missing start value for NVRAM encoding" (e.g. free_play / game_over / tilted in the Capcom bbb108 / bbb109 maps).

Route bool through location_in_nvram_file / location_for like the other encodings so it accepts both start and offsets. Also drop a stray debug println in the bool read path.

Add unit tests covering continuous and scattered bool reads (incl. invert).