### PR TITLE
test(resolve): ratchet on unexpected resolve warnings

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -640,6 +640,11 @@ mod tests {
     /// match testdata/aaa_expected_warnings.txt exactly. A new unexpected
     /// warning fails here even when added together with a fresh golden
     /// .nv.json, and a fixed warning must be removed from the list on purpose.
+    ///
+    /// The failure message is directional: warnings present now but missing
+    /// from the file are flagged as regressions to investigate, while warnings
+    /// in the file that no longer occur are flagged for removal (e.g. after an
+    /// upstream map fix).
     #[test]
     fn test_expected_warnings() -> io::Result<()> {
         let test_dir = testdir!();
@@ -657,18 +662,43 @@ mod tests {
                 collect_warnings(&rom, &value, &mut actual);
             }
         }
-        actual.sort();
+        let actual: std::collections::BTreeSet<String> = actual.into_iter().collect();
 
         let expected_content = std::fs::read_to_string("testdata/aaa_expected_warnings.txt")?;
-        let mut expected: Vec<String> = expected_content
+        let expected: std::collections::BTreeSet<String> = expected_content
             .lines()
             .map(|l| l.trim())
             .filter(|l| !l.is_empty() && !l.starts_with('#'))
             .map(|l| l.to_string())
             .collect();
-        expected.sort();
 
-        assert_eq!(actual, expected);
+        let new: Vec<&String> = actual.difference(&expected).collect();
+        let resolved: Vec<&String> = expected.difference(&actual).collect();
+
+        if !new.is_empty() || !resolved.is_empty() {
+            let mut msg = String::from(
+                "resolve warnings differ from testdata/aaa_expected_warnings.txt\n",
+            );
+            if !new.is_empty() {
+                msg.push_str(
+                    "\nNEW unexpected warnings - a regression to investigate, \
+                     or add these lines to the file if intended:\n",
+                );
+                for w in &new {
+                    msg.push_str(&format!("  + {w}\n"));
+                }
+            }
+            if !resolved.is_empty() {
+                msg.push_str(
+                    "\nExpected warnings that no longer occur - remove these lines \
+                     from the file:\n",
+                );
+                for w in &resolved {
+                    msg.push_str(&format!("  - {w}\n"));
+                }
+            }
+            panic!("{msg}");
+        }
         Ok(())
     }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -609,6 +609,69 @@ mod tests {
         Ok(())
     }
 
+    /// Warnings of this kind are tolerated wholesale by the ratchet: the value
+    /// is simply not part of the dumped NVRAM region, which is common and
+    /// expected, so we do not enumerate them in the expected-warnings file.
+    const OUTSIDE_NVRAM_WARNING: &str = "Value is stored outside the NVRAM";
+
+    fn collect_warnings(rom: &str, value: &Value, out: &mut Vec<String>) {
+        match value {
+            Value::Object(map) => {
+                if let Some(Value::String(warning)) = map.get("warning") {
+                    if !warning.contains(OUTSIDE_NVRAM_WARNING) {
+                        let label = map.get("label").and_then(|l| l.as_str()).unwrap_or("(no label)");
+                        out.push(format!("{rom} | {label} | {warning}"));
+                    }
+                }
+                for v in map.values() {
+                    collect_warnings(rom, v, out);
+                }
+            }
+            Value::Array(array) => {
+                for v in array {
+                    collect_warnings(rom, v, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Ratchet: the set of resolve warnings (excluding "outside NVRAM") must
+    /// match testdata/aaa_expected_warnings.txt exactly. A new unexpected
+    /// warning fails here even when added together with a fresh golden
+    /// .nv.json, and a fixed warning must be removed from the list on purpose.
+    #[test]
+    fn test_expected_warnings() -> io::Result<()> {
+        let test_dir = testdir!();
+        let mut actual = Vec::new();
+        for entry in std::fs::read_dir("testdata")? {
+            let nvram_path = entry?.path();
+            if nvram_path.extension().and_then(|e| e.to_str()) != Some("nv") {
+                continue;
+            }
+            // The display name keeps the original file stem (e.g. the
+            // "-default" suffix), while resolving needs the rom-named path.
+            let rom = nvram_path.file_stem().unwrap().to_str().unwrap().to_string();
+            let path = path_for_test(&test_dir, &nvram_path)?;
+            if let Some(value) = resolve(&path)? {
+                collect_warnings(&rom, &value, &mut actual);
+            }
+        }
+        actual.sort();
+
+        let expected_content = std::fs::read_to_string("testdata/aaa_expected_warnings.txt")?;
+        let mut expected: Vec<String> = expected_content
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty() && !l.starts_with('#'))
+            .map(|l| l.to_string())
+            .collect();
+        expected.sort();
+
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
     fn path_for_test(test_dir: &Path, nvram_path: &PathBuf) -> io::Result<PathBuf> {
         let path = if nvram_path
             .file_name()

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -617,11 +617,11 @@ mod tests {
     fn collect_warnings(rom: &str, value: &Value, out: &mut Vec<String>) {
         match value {
             Value::Object(map) => {
-                if let Some(Value::String(warning)) = map.get("warning") {
-                    if !warning.contains(OUTSIDE_NVRAM_WARNING) {
-                        let label = map.get("label").and_then(|l| l.as_str()).unwrap_or("(no label)");
-                        out.push(format!("{rom} | {label} | {warning}"));
-                    }
+                if let Some(Value::String(warning)) = map.get("warning")
+                    && !warning.contains(OUTSIDE_NVRAM_WARNING)
+                {
+                    let label = map.get("label").and_then(|l| l.as_str()).unwrap_or("(no label)");
+                    out.push(format!("{rom} | {label} | {warning}"));
                 }
                 for v in map.values() {
                     collect_warnings(rom, v, out);

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -620,7 +620,10 @@ mod tests {
                 if let Some(Value::String(warning)) = map.get("warning")
                     && !warning.contains(OUTSIDE_NVRAM_WARNING)
                 {
-                    let label = map.get("label").and_then(|l| l.as_str()).unwrap_or("(no label)");
+                    let label = map
+                        .get("label")
+                        .and_then(|l| l.as_str())
+                        .unwrap_or("(no label)");
                     out.push(format!("{rom} | {label} | {warning}"));
                 }
                 for v in map.values() {
@@ -656,7 +659,12 @@ mod tests {
             }
             // The display name keeps the original file stem (e.g. the
             // "-default" suffix), while resolving needs the rom-named path.
-            let rom = nvram_path.file_stem().unwrap().to_str().unwrap().to_string();
+            let rom = nvram_path
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string();
             let path = path_for_test(&test_dir, &nvram_path)?;
             if let Some(value) = resolve(&path)? {
                 collect_warnings(&rom, &value, &mut actual);
@@ -676,9 +684,8 @@ mod tests {
         let resolved: Vec<&String> = expected.difference(&actual).collect();
 
         if !new.is_empty() || !resolved.is_empty() {
-            let mut msg = String::from(
-                "resolve warnings differ from testdata/aaa_expected_warnings.txt\n",
-            );
+            let mut msg =
+                String::from("resolve warnings differ from testdata/aaa_expected_warnings.txt\n");
             if !new.is_empty() {
                 msg.push_str(
                     "\nNEW unexpected warnings - a regression to investigate, \

--- a/testdata/aaa_expected_warnings.txt
+++ b/testdata/aaa_expected_warnings.txt
@@ -1,0 +1,43 @@
+# Expected resolve warnings (the warning ratchet, see test_expected_warnings).
+#
+# Every "<rom> | <label> | <message>" line below is a warning the resolver is
+# currently expected to emit for a testdata nvram, EXCLUDING the common
+# "Value is stored outside the NVRAM" (those are tolerated wholesale: the value
+# simply is not part of the dumped region).
+#
+# The test fails if the set of emitted warnings differs from this list. That
+# makes any NEW unexpected warning a hard failure (so a new map/encoding bug
+# cannot be silently codified as a golden .nv.json, the way it could before),
+# and forces fixed warnings to be removed from this list deliberately.
+#
+# Most entries below are uninitialised / out-of-spec dump data (e.g. Volume 255
+# where the valid range is 0-31, or an enum index from a factory-default byte).
+# Known map bugs worth fixing upstream are called out with a NOTE comment.
+#
+# Lines starting with '#' and blank lines are ignored.
+
+bop_l8 | Volume | Value out of range: 0 ≤ 255 ≤ 31
+# NOTE: disco_l1 map bug - "Play" min should be 1, not 2 (index 1 is a real
+#       setting "normal (1 & 2 together)"); remove once fixed upstream.
+disco_l1 | Play | Value out of range: 2 ≤ 1 ≤ 4
+eballdlx | Backbox Deluxe Feature | Value out of range: 0 ≤ 15 ≤ 3
+embryon | Replay Award | Failed to resolve: Index 15 out of bounds for enum with 4 values
+embryon | Sound Option | Failed to resolve: Index 15 out of bounds for enum with 4 values
+embryon | Special/Extra Ball Awards | Failed to resolve: Index 15 out of bounds for enum with 4 values
+embryond | Replay Award | Failed to resolve: Index 15 out of bounds for enum with 4 values
+embryond | Sound Option | Failed to resolve: Index 15 out of bounds for enum with 4 values
+embryond | Special/Extra Ball Awards | Failed to resolve: Index 15 out of bounds for enum with 4 values
+fball_ii | Replay Award | Failed to resolve: Index 15 out of bounds for enum with 4 values
+fball_ii | Sound Option | Failed to resolve: Index 15 out of bounds for enum with 4 values
+fball_ii | Special/Extra Ball Awards | Failed to resolve: Index 15 out of bounds for enum with 4 values
+flashgdn | Replay Award | Failed to resolve: Index 15 out of bounds for enum with 4 values
+flashgdn | Sound Option | Failed to resolve: Index 15 out of bounds for enum with 4 values
+flashgdn | Special/Extra Ball Awards | Failed to resolve: Index 15 out of bounds for enum with 4 values
+mb_106 | Volume | Value out of range: 0 ≤ 255 ≤ 31
+ratrc_l1 | Replay Award | Failed to resolve: Index 85 out of bounds for enum with 2 values
+sshtl_l7 | Match | Failed to resolve: Index 2 out of bounds for enum with 2 values
+taf_h4 | Volume | Value out of range: 0 ≤ 255 ≤ 31
+taf_l5 | Volume | Value out of range: 0 ≤ 255 ≤ 31
+tom_14h | Volume | Value out of range: 0 ≤ 255 ≤ 31
+tsptr_l3 | Replay Start | Value out of range: 8 ≤ 25 ≤ 20
+wd_12g | Volume | Value out of range: 0 ≤ 255 ≤ 31


### PR DESCRIPTION
Add test_expected_warnings: it resolves every testdata nvram, collects the warnings (excluding the common "Value is stored outside the NVRAM"), and asserts the set matches testdata/aaa_expected_warnings.txt.

Previously a warning only had to match its golden .nv.json, so a new map or encoding bug could be silently codified as expected the first time a testdata file was added (as happened with the bbb109 bool game_state warnings). This ratchet makes any new, unexpected warning a hard failure and forces fixed warnings to be removed from the list deliberately.

Seed the list with the current warnings, and flag the disco_l1 "Play" entry as a known upstream map bug (min should be 1, not 2).