### PR TITLE
feat(resolve): honor special_values and offset for int/bcd

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -118,6 +118,35 @@ fn resolve_recursive<T: Read + Seek, S: GlobalSettings>(
     Ok(result)
 }
 
+/// The `offset` property: a value added to a decoded `int`/`bcd` value before
+/// display (applied after `scale`). Defaults to 0.
+fn value_offset(descriptor: &Map<String, Value>) -> i128 {
+    descriptor
+        .get("offset")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0) as i128
+}
+
+/// If the descriptor has a `special_values` override for this displayed integer
+/// (e.g. `{"0": "OFF"}`), return its label. The key is matched against the
+/// value after `scale` and `offset` have been applied.
+fn special_value(descriptor: &Map<String, Value>, value: i128) -> Option<String> {
+    descriptor
+        .get("special_values")?
+        .as_object()?
+        .get(&value.to_string())?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn number_from_i128(v: i128) -> Number {
+    if (0..=u64::MAX as i128).contains(&v) {
+        Number::from(v as u64)
+    } else {
+        Number::from(v as i64)
+    }
+}
+
 /// Validate the raw numeric value against the descriptor's min and max range.
 /// If the value is out of range a warning is returned.
 ///
@@ -243,8 +272,12 @@ fn resolve_value<T: Read + Seek, U: GlobalSettings>(
                 .unwrap_or(Number::from(DEFAULT_SCALE));
             let location = location_in_nvram_file(nvram_layout, descriptor, length)?;
             let value = read_int(rom, endian, nibble, location, &scale)?;
+            let display = value as i128 + value_offset(descriptor);
+            if let Some(label) = special_value(descriptor, display) {
+                return Ok((Value::String(label), None));
+            }
             range_value = Some(value);
-            Value::Number(value.into())
+            Value::Number(number_from_i128(display))
         }
         Encoding::Enum => {
             let location = location_in_nvram_file(nvram_layout, descriptor, length)?;
@@ -283,8 +316,12 @@ fn resolve_value<T: Read + Seek, U: GlobalSettings>(
                 .unwrap_or(nibble);
 
             let value = read_bcd(rom, location, nibble, &scale, endian)?;
+            let display = value as i128 + value_offset(descriptor);
+            if let Some(label) = special_value(descriptor, display) {
+                return Ok((Value::String(label), None));
+            }
             range_value = Some(value);
-            Value::Number(value.into())
+            Value::Number(number_from_i128(display))
         }
         Encoding::Ch => {
             let location = location_in_nvram_file(nvram_layout, descriptor, length)?;
@@ -492,6 +529,37 @@ mod tests {
     fn test_validate_range_no_bounds() {
         // a descriptor without min/max is never range-checked
         assert_eq!(validate_range(&Map::new(), Some(255)), None);
+    }
+
+    #[test]
+    fn test_value_offset() {
+        assert_eq!(value_offset(&Map::new()), 0);
+        let mut m = Map::new();
+        m.insert("offset".to_string(), Value::from(1));
+        assert_eq!(value_offset(&m), 1);
+        m.insert("offset".to_string(), Value::from(-3));
+        assert_eq!(value_offset(&m), -3);
+    }
+
+    #[test]
+    fn test_special_value() {
+        let mut sv = Map::new();
+        sv.insert("0".to_string(), Value::from("OFF"));
+        sv.insert("256".to_string(), Value::from("n/a"));
+        let mut m = Map::new();
+        m.insert("special_values".to_string(), Value::Object(sv));
+        assert_eq!(special_value(&m, 0), Some("OFF".to_string()));
+        assert_eq!(special_value(&m, 256), Some("n/a".to_string()));
+        assert_eq!(special_value(&m, 1), None);
+        // no special_values at all
+        assert_eq!(special_value(&Map::new(), 0), None);
+    }
+
+    #[test]
+    fn test_number_from_i128() {
+        assert_eq!(number_from_i128(255), Number::from(255u64));
+        assert_eq!(number_from_i128(0), Number::from(0u64));
+        assert_eq!(number_from_i128(-3), Number::from(-3i64));
     }
 
     #[test]

--- a/testdata/afm_113.nv.json
+++ b/testdata/afm_113.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,15 +40,15 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",

--- a/testdata/afm_113b-buyin.nv.json
+++ b/testdata/afm_113b-buyin.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,15 +40,15 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",

--- a/testdata/afm_113b.nv.json
+++ b/testdata/afm_113b.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,15 +40,15 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",

--- a/testdata/algar_l1.nv.json
+++ b/testdata/algar_l1.nv.json
@@ -62,7 +62,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/$0.25"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -167,7 +167,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/alpok_l6.nv.json
+++ b/testdata/alpok_l6.nv.json
@@ -62,7 +62,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 1
+        "value": "1/$0.25, 3/$0.50"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -167,7 +167,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/barra_l1.nv.json
+++ b/testdata/barra_l1.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/bbnny_l2.nv.json
+++ b/testdata/bbnny_l2.nv.json
@@ -215,11 +215,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -239,7 +239,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/bcats_l5.nv.json
+++ b/testdata/bcats_l5.nv.json
@@ -235,11 +235,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -259,7 +259,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/bguns_l8.nv.json
+++ b/testdata/bguns_l8.nv.json
@@ -179,11 +179,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -203,7 +203,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/bk2k_l4.nv.json
+++ b/testdata/bk2k_l4.nv.json
@@ -211,7 +211,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -231,7 +231,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/bk_l4.nv.json
+++ b/testdata/bk_l4.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/blackjck.nv.json
+++ b/testdata/blackjck.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/blakpyra.nv.json
+++ b/testdata/blakpyra.nv.json
@@ -4,11 +4,11 @@
     "Game Adjustments": {
       "16": {
         "label": "Special/EB/Novelty",
-        "value": 0
+        "value": "no award"
       },
       "17": {
         "label": "Replay Award",
-        "value": 0
+        "value": "nothing"
       },
       "18": {
         "label": "Unused",
@@ -22,15 +22,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/blkou_l1.nv.json
+++ b/testdata/blkou_l1.nv.json
@@ -50,7 +50,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/$0.25"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -151,7 +151,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/bmx.nv.json
+++ b/testdata/bmx.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/bnzai_l3.nv.json
+++ b/testdata/bnzai_l3.nv.json
@@ -187,7 +187,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -207,7 +207,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/cactjack.nv.json
+++ b/testdata/cactjack.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/carhop.nv.json
+++ b/testdata/carhop.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/ccruise.nv.json
+++ b/testdata/ccruise.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/centaur-2.nv.json
+++ b/testdata/centaur-2.nv.json
@@ -4,11 +4,11 @@
     "Game Adjustments": {
       "16": {
         "label": "High Score award #1",
-        "value": 0
+        "value": "No Award"
       },
       "17": {
         "label": "High Score award #2",
-        "value": 0
+        "value": "No Award"
       },
       "18": {
         "label": "???",
@@ -34,11 +34,11 @@
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/centaur.nv.json
+++ b/testdata/centaur.nv.json
@@ -4,11 +4,11 @@
     "Game Adjustments": {
       "16": {
         "label": "High Score award #1",
-        "value": 0
+        "value": "No Award"
       },
       "17": {
         "label": "High Score award #2",
-        "value": 0
+        "value": "No Award"
       },
       "18": {
         "label": "???",
@@ -30,15 +30,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/centaura.nv.json
+++ b/testdata/centaura.nv.json
@@ -4,11 +4,11 @@
     "Game Adjustments": {
       "16": {
         "label": "High Score award #1",
-        "value": 0
+        "value": "No Award"
       },
       "17": {
         "label": "High Score award #2",
-        "value": 0
+        "value": "No Award"
       },
       "18": {
         "label": "???",
@@ -30,15 +30,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/clas1812.nv.json
+++ b/testdata/clas1812.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/cntct_l1.nv.json
+++ b/testdata/cntct_l1.nv.json
@@ -24,7 +24,7 @@
       },
       "06": {
         "label": "Match/Credit/Extra Ball",
-        "value": 10
+        "value": "match on, replay awards credit"
       },
       "07": {
         "label": "Play",
@@ -96,7 +96,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/comet_l5.nv.json
+++ b/testdata/comet_l5.nv.json
@@ -244,11 +244,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",
@@ -268,7 +268,7 @@
     },
     "player_count": {
       "label": "Players",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/csmic_l1.nv.json
+++ b/testdata/csmic_l1.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/cueball.nv.json
+++ b/testdata/cueball.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "game_over": {
       "label": "Game Over",

--- a/testdata/cv_20h.nv.json
+++ b/testdata/cv_20h.nv.json
@@ -657,7 +657,7 @@
     },
     "credits": {
       "label": "Credits",
-      "value": 255
+      "value": "FREE ONLY"
     },
     "current_ball": {
       "label": "Ball",

--- a/testdata/cybrnaut.nv.json
+++ b/testdata/cybrnaut.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/cycln_l5.nv.json
+++ b/testdata/cycln_l5.nv.json
@@ -187,7 +187,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -207,7 +207,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/dd_l2.nv.json
+++ b/testdata/dd_l2.nv.json
@@ -223,7 +223,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -243,7 +243,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/deadweap.nv.json
+++ b/testdata/deadweap.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/dfndr_l4.nv.json
+++ b/testdata/dfndr_l4.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/diner_l4.nv.json
+++ b/testdata/diner_l4.nv.json
@@ -223,7 +223,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -243,7 +243,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/disco_l1.nv.json
+++ b/testdata/disco_l1.nv.json
@@ -24,7 +24,7 @@
       },
       "06": {
         "label": "Match/Credit/Extra Ball",
-        "value": 8
+        "value": "match on, replay awards credit"
       },
       "07": {
         "label": "Play",
@@ -101,7 +101,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/dm_h6.nv.json
+++ b/testdata/dm_h6.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P.",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,15 +40,15 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",
@@ -150,7 +150,7 @@
       },
       "04": {
         "label": "Timed Plunger",
-        "value": 29
+        "value": "OFF"
       },
       "05": {
         "label": "Ex. Ball Percent",

--- a/testdata/dm_lx4.nv.json
+++ b/testdata/dm_lx4.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P.",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,15 +40,15 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",
@@ -150,7 +150,7 @@
       },
       "04": {
         "label": "Timed Plunger",
-        "value": 29
+        "value": "OFF"
       },
       "05": {
         "label": "Ex. Ball Percent",

--- a/testdata/dollyptb.nv.json
+++ b/testdata/dollyptb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/drac_l1.nv.json
+++ b/testdata/drac_l1.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B Per B.I.P",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -154,11 +154,11 @@
       },
       "09": {
         "label": "Pre-lite V.Mode",
-        "value": 0
+        "value": "NONE"
       },
       "10": {
         "label": "V.Mode Award",
-        "value": 0
+        "value": "NONE"
       },
       "11": {
         "label": "Bonus 'X' Memory",
@@ -178,7 +178,7 @@
       },
       "15": {
         "label": "Pre-lite Coffin",
-        "value": 0
+        "value": "NONE"
       },
       "16": {
         "label": "Coffin Ramp Time",
@@ -270,7 +270,7 @@
       },
       "38": {
         "label": "Timed Plunger",
-        "value": 0
+        "value": "OFF"
       },
       "39": {
         "label": "Flipped Plunger",

--- a/testdata/eatpm_l4.nv.json
+++ b/testdata/eatpm_l4.nv.json
@@ -211,7 +211,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -231,7 +231,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/eballdlx.nv.json
+++ b/testdata/eballdlx.nv.json
@@ -4,11 +4,11 @@
     "Game Adjustments": {
       "16": {
         "label": "High Score award #1",
-        "value": 0
+        "value": "No Award"
       },
       "17": {
         "label": "High Score award #2",
-        "value": 0
+        "value": "No Award"
       },
       "18": {
         "label": "???",
@@ -35,15 +35,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/eightbll.nv.json
+++ b/testdata/eightbll.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/elektra.nv.json
+++ b/testdata/elektra.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/embryon.nv.json
+++ b/testdata/embryon.nv.json
@@ -4,15 +4,15 @@
     "Adjustments": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "16": {
         "label": "Special/Extra Ball Awards",

--- a/testdata/embryond.nv.json
+++ b/testdata/embryond.nv.json
@@ -4,15 +4,15 @@
     "Adjustments": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "16": {
         "label": "Special/Extra Ball Awards",

--- a/testdata/esha_l4c.nv.json
+++ b/testdata/esha_l4c.nv.json
@@ -211,7 +211,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -231,7 +231,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/esha_la3.nv.json
+++ b/testdata/esha_la3.nv.json
@@ -211,7 +211,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -231,7 +231,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/esha_ma3.nv.json
+++ b/testdata/esha_ma3.nv.json
@@ -211,7 +211,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -231,7 +231,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 1
+      "value": 2
     },
     "scores": [
       {

--- a/testdata/evelknie.nv.json
+++ b/testdata/evelknie.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/f14_l1.nv.json
+++ b/testdata/f14_l1.nv.json
@@ -163,7 +163,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -183,7 +183,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/fathom.nv.json
+++ b/testdata/fathom.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/fball_ii.nv.json
+++ b/testdata/fball_ii.nv.json
@@ -4,15 +4,15 @@
     "Adjustments": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "16": {
         "label": "Special/Extra Ball Awards",

--- a/testdata/fbclass.nv.json
+++ b/testdata/fbclass.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/fire_l3.nv.json
+++ b/testdata/fire_l3.nv.json
@@ -163,7 +163,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -183,7 +183,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/flash_l1.nv.json
+++ b/testdata/flash_l1.nv.json
@@ -54,7 +54,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 1
+        "value": "1/$0.25, 3/$0.50"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -155,7 +155,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/flashgdn.nv.json
+++ b/testdata/flashgdn.nv.json
@@ -4,15 +4,15 @@
     "Adjustments": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "16": {
         "label": "Special/Extra Ball Awards",

--- a/testdata/fpwr2_l2.nv.json
+++ b/testdata/fpwr2_l2.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/freddy.nv.json
+++ b/testdata/freddy.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "game_over": {
       "label": "Game Over",

--- a/testdata/freedom.nv.json
+++ b/testdata/freedom.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "07": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "08": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "09": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "10": {
         "label": "High score to date",

--- a/testdata/futurspa.nv.json
+++ b/testdata/futurspa.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/gransla4.nv.json
+++ b/testdata/gransla4.nv.json
@@ -4,15 +4,15 @@
     "Adjustments": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/grgar_l1.nv.json
+++ b/testdata/grgar_l1.nv.json
@@ -50,7 +50,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 5
+        "value": "1/1F, 7/5F"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -151,7 +151,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/gs_la3.nv.json
+++ b/testdata/gs_la3.nv.json
@@ -215,11 +215,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -239,7 +239,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/gs_lu4.nv.json
+++ b/testdata/gs_lu4.nv.json
@@ -215,11 +215,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -239,7 +239,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/hglbtrtb.nv.json
+++ b/testdata/hglbtrtb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/hoops.nv.json
+++ b/testdata/hoops.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/hotdoggb.nv.json
+++ b/testdata/hotdoggb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/hotdoggn.nv.json
+++ b/testdata/hotdoggn.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/hothand.nv.json
+++ b/testdata/hothand.nv.json
@@ -93,7 +93,7 @@
     },
     "match": {
       "label": "Match",
-      "value": 2
+      "value": "n/a"
     },
     "max_credits": {
       "label": "Max Credits",

--- a/testdata/hs_l4.nv.json
+++ b/testdata/hs_l4.nv.json
@@ -16,19 +16,19 @@
       },
       "03a": {
         "label": "Replay Levels",
-        "value": 0
+        "value": 1
       },
       "03b": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "Off"
       },
       "04b": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "Off"
       },
       "05b": {
         "label": "Replay Level 4",
-        "value": 0
+        "value": "Off"
       },
       "06": {
         "label": "Replay Award",
@@ -419,7 +419,7 @@
     },
     "bonus_hold": {
       "label": "Bonus Hold",
-      "value": 0
+      "value": "No"
     },
     "credits": {
       "label": "Credits",
@@ -427,11 +427,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -459,7 +459,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/httip_l1.nv.json
+++ b/testdata/httip_l1.nv.json
@@ -100,7 +100,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/hypbl_l6.nv.json
+++ b/testdata/hypbl_l6.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/jm_12r.nv.json
+++ b/testdata/jm_12r.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P.",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,19 +40,19 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",
-        "value": 50
+        "value": "AUTO"
       },
       "14": {
         "label": "Replay Award",
@@ -154,7 +154,7 @@
       },
       "05": {
         "label": "Timed Plunger",
-        "value": 29
+        "value": "OFF"
       },
       "06": {
         "label": "Flipper Plunger",
@@ -202,7 +202,7 @@
       },
       "17": {
         "label": "Hand Position Y",
-        "value": 56
+        "value": -24
       },
       "18": {
         "label": "Hand Disabled",

--- a/testdata/jngld_l2.nv.json
+++ b/testdata/jngld_l2.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/jokrz_l6.nv.json
+++ b/testdata/jokrz_l6.nv.json
@@ -211,7 +211,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -231,7 +231,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/jst_l2.nv.json
+++ b/testdata/jst_l2.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/kissb.nv.json
+++ b/testdata/kissb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/kissc.nv.json
+++ b/testdata/kissc.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/kosteel.nv.json
+++ b/testdata/kosteel.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/kosteela.nv.json
+++ b/testdata/kosteela.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/lca.nv.json
+++ b/testdata/lca.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/lca2.nv.json
+++ b/testdata/lca2.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/lectrono.nv.json
+++ b/testdata/lectrono.nv.json
@@ -93,7 +93,7 @@
     },
     "match": {
       "label": "Match",
-      "value": 1
+      "value": "n/a"
     },
     "max_credits": {
       "label": "Max Credits",

--- a/testdata/lsrcu_l2.nv.json
+++ b/testdata/lsrcu_l2.nv.json
@@ -17,7 +17,7 @@
       "33": {
         "label": "Extra Ball Time",
         "units": "seconds",
-        "value": 10
+        "value": 25
       },
       "34": {
         "label": "Reset Back Drop-Targets",
@@ -71,7 +71,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -139,7 +139,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/lzbal_l2.nv.json
+++ b/testdata/lzbal_l2.nv.json
@@ -50,7 +50,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/$0.25"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -151,7 +151,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/m_mpac.nv.json
+++ b/testdata/m_mpac.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/matahari.nv.json
+++ b/testdata/matahari.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/medusa.nv.json
+++ b/testdata/medusa.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/mousn_l4.nv.json
+++ b/testdata/mousn_l4.nv.json
@@ -219,7 +219,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -239,7 +239,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/mystic.nv.json
+++ b/testdata/mystic.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/mysticb.nv.json
+++ b/testdata/mysticb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/nbaf_31.nv.json
+++ b/testdata/nbaf_31.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P.",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,19 +40,19 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",
-        "value": 1
+        "value": "AUTO"
       },
       "14": {
         "label": "Replay Award",

--- a/testdata/newwave.nv.json
+++ b/testdata/newwave.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/ngndshkb.nv.json
+++ b/testdata/ngndshkb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/ngndshkr.nv.json
+++ b/testdata/ngndshkr.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/nightrdr.nv.json
+++ b/testdata/nightrdr.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/nugent.nv.json
+++ b/testdata/nugent.nv.json
@@ -93,7 +93,7 @@
     },
     "match": {
       "label": "Match",
-      "value": 1
+      "value": "n/a"
     },
     "max_credits": {
       "label": "Max Credits",

--- a/testdata/opthund.nv.json
+++ b/testdata/opthund.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/paragon.nv.json
+++ b/testdata/paragon.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/pb_l5.nv.json
+++ b/testdata/pb_l5.nv.json
@@ -159,11 +159,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -183,7 +183,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/pharo_l2.nv.json
+++ b/testdata/pharo_l2.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/phnix_l1.nv.json
+++ b/testdata/phnix_l1.nv.json
@@ -24,7 +24,7 @@
       },
       "06": {
         "label": "Match/Credit/Extra Ball",
-        "value": 8
+        "value": "match on, replay awards credit"
       },
       "07": {
         "label": "Play",
@@ -100,7 +100,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/pinball.nv.json
+++ b/testdata/pinball.nv.json
@@ -93,7 +93,7 @@
     },
     "match": {
       "label": "Match",
-      "value": 2
+      "value": "n/a"
     },
     "max_credits": {
       "label": "Max Credits",

--- a/testdata/pkrno_l1.nv.json
+++ b/testdata/pkrno_l1.nv.json
@@ -24,7 +24,7 @@
       },
       "06": {
         "label": "Match/Credit/Extra Ball",
-        "value": 10
+        "value": "match on, replay awards credit"
       },
       "07": {
         "label": "Play",
@@ -100,7 +100,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/playboy.nv.json
+++ b/testdata/playboy.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/playboyb.nv.json
+++ b/testdata/playboyb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/polic_l4.nv.json
+++ b/testdata/polic_l4.nv.json
@@ -219,7 +219,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -239,7 +239,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/pool_l7.nv.json
+++ b/testdata/pool_l7.nv.json
@@ -219,7 +219,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -239,7 +239,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/pwerplay.nv.json
+++ b/testdata/pwerplay.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/radcl_l1.nv.json
+++ b/testdata/radcl_l1.nv.json
@@ -219,7 +219,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -239,7 +239,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/ratrc_l1.nv.json
+++ b/testdata/ratrc_l1.nv.json
@@ -62,11 +62,11 @@
       },
       "18": {
         "label": "Maximum Credits",
-        "value": 0
+        "value": "Free Play"
       },
       "19": {
         "label": "Pricing Control",
-        "value": 0
+        "value": "Manual"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",

--- a/testdata/rdkng_l4.nv.json
+++ b/testdata/rdkng_l4.nv.json
@@ -163,7 +163,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -183,7 +183,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/rollr_l2.nv.json
+++ b/testdata/rollr_l2.nv.json
@@ -215,7 +215,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -235,7 +235,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/rollstob.nv.json
+++ b/testdata/rollstob.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/scrpn_l1.nv.json
+++ b/testdata/scrpn_l1.nv.json
@@ -50,7 +50,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/$0.25"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -151,7 +151,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/silvslug.nv.json
+++ b/testdata/silvslug.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/slbmanib.nv.json
+++ b/testdata/slbmanib.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/solar_l2.nv.json
+++ b/testdata/solar_l2.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/sorcr_l1.nv.json
+++ b/testdata/sorcr_l1.nv.json
@@ -244,11 +244,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",
@@ -268,7 +268,7 @@
     },
     "player_count": {
       "label": "Players",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/sorcr_l2.nv.json
+++ b/testdata/sorcr_l2.nv.json
@@ -248,7 +248,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",
@@ -268,7 +268,7 @@
     },
     "player_count": {
       "label": "Players",
-      "value": 255
+      "value": "n/a"
     },
     "scores": [
       {

--- a/testdata/spaceinb.nv.json
+++ b/testdata/spaceinb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/speakes4.nv.json
+++ b/testdata/speakes4.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/speakesy.nv.json
+++ b/testdata/speakesy.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/spectru4.nv.json
+++ b/testdata/spectru4.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/spstn_l5.nv.json
+++ b/testdata/spstn_l5.nv.json
@@ -183,7 +183,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -203,7 +203,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/spyhuntr.nv.json
+++ b/testdata/spyhuntr.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/sshtl_l7.nv.json
+++ b/testdata/sshtl_l7.nv.json
@@ -244,11 +244,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",
@@ -268,7 +268,7 @@
     },
     "player_count": {
       "label": "Players",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/sst.nv.json
+++ b/testdata/sst.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/sstb.nv.json
+++ b/testdata/sstb.nv.json
@@ -12,7 +12,7 @@
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/stars.nv.json
+++ b/testdata/stars.nv.json
@@ -93,7 +93,7 @@
     },
     "match": {
       "label": "Match",
-      "value": 2
+      "value": "n/a"
     },
     "max_credits": {
       "label": "Max Credits",

--- a/testdata/startreb.nv.json
+++ b/testdata/startreb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/stingray.nv.json
+++ b/testdata/stingray.nv.json
@@ -93,7 +93,7 @@
     },
     "match": {
       "label": "Match",
-      "value": 2
+      "value": "n/a"
     },
     "max_credits": {
       "label": "Max Credits",

--- a/testdata/stk_sprs.nv.json
+++ b/testdata/stk_sprs.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/stlwr_l2.nv.json
+++ b/testdata/stlwr_l2.nv.json
@@ -16,7 +16,7 @@
       },
       "35": {
         "label": "Sweep Sound Select",
-        "value": 0
+        "value": "disabled"
       }
     },
     "Standard Adjustments": {
@@ -46,7 +46,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/$0.25"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -147,7 +147,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/strlt_l1.nv.json
+++ b/testdata/strlt_l1.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/suprbowl.nv.json
+++ b/testdata/suprbowl.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/surfnsaf.nv.json
+++ b/testdata/surfnsaf.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/swrds_l2.nv.json
+++ b/testdata/swrds_l2.nv.json
@@ -187,7 +187,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -207,7 +207,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/taxi_l4.nv.json
+++ b/testdata/taxi_l4.nv.json
@@ -195,7 +195,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 1
+      "value": 2
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -215,7 +215,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 1
+      "value": 2
     },
     "scores": [
       {

--- a/testdata/tfight.nv.json
+++ b/testdata/tfight.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/thund_p2.nv.json
+++ b/testdata/thund_p2.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/thund_p3.nv.json
+++ b/testdata/thund_p3.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/tmfnt_l5.nv.json
+++ b/testdata/tmfnt_l5.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/tmwrp_l2.nv.json
+++ b/testdata/tmwrp_l2.nv.json
@@ -50,7 +50,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 5
+        "value": "1/1F, 7/5F"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -151,7 +151,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/tom_13.nv.json
+++ b/testdata/tom_13.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P.",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,15 +40,15 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",

--- a/testdata/tom_14h.nv.json
+++ b/testdata/tom_14h.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P.",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,15 +40,15 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",

--- a/testdata/tom_14hb.nv.json
+++ b/testdata/tom_14hb.nv.json
@@ -16,7 +16,7 @@
       },
       "04": {
         "label": "Max E.B. Per B.I.P.",
-        "value": 0
+        "value": "OFF"
       },
       "05": {
         "label": "Replay System",
@@ -40,15 +40,15 @@
       },
       "10": {
         "label": "Replay L2",
-        "value": 0
+        "value": "OFF"
       },
       "11": {
         "label": "Replay L3",
-        "value": 0
+        "value": "OFF"
       },
       "12": {
         "label": "Replay L4",
-        "value": 0
+        "value": "OFF"
       },
       "13": {
         "label": "Replay Boost",

--- a/testdata/trizn_l1.nv.json
+++ b/testdata/trizn_l1.nv.json
@@ -50,7 +50,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 1
+        "value": "1/$0.25, 3/$0.50"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -151,7 +151,7 @@
       },
       "99": {
         "label": "Check Byte",
-        "value": 90
+        "value": "valid"
       }
     }
   },

--- a/testdata/tsptr_l3.nv.json
+++ b/testdata/tsptr_l3.nv.json
@@ -17,19 +17,19 @@
       },
       "03a": {
         "label": "Replay Levels",
-        "value": 0
+        "value": 1
       },
       "03b": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "Off"
       },
       "04b": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "Off"
       },
       "05b": {
         "label": "Replay Level 4",
-        "value": 0
+        "value": "Off"
       },
       "06": {
         "label": "Replay Award",
@@ -460,11 +460,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -492,7 +492,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "playfield_mult": {
       "label": "Playfield Multiplier",

--- a/testdata/vector.nv.json
+++ b/testdata/vector.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/vegas.nv.json
+++ b/testdata/vegas.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "free_play": {
       "label": "Free Play",

--- a/testdata/vikingb.nv.json
+++ b/testdata/vikingb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/voltanb.nv.json
+++ b/testdata/voltanb.nv.json
@@ -4,15 +4,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",

--- a/testdata/vrkon_l1.nv.json
+++ b/testdata/vrkon_l1.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/waterwld.nv.json
+++ b/testdata/waterwld.nv.json
@@ -15,7 +15,7 @@
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "game_over": {
       "label": "Game Over",

--- a/testdata/whirl_l3.nv.json
+++ b/testdata/whirl_l3.nv.json
@@ -219,11 +219,11 @@
     },
     "current_ball": {
       "label": "Ball",
-      "value": 0
+      "value": "n/a"
     },
     "current_player": {
       "label": "Current Player",
-      "value": 0
+      "value": 1
     },
     "extra_balls": {
       "label": "Extra Balls",
@@ -243,7 +243,7 @@
     },
     "player_count": {
       "label": "Player Count",
-      "value": 0
+      "value": 1
     },
     "scores": [
       {

--- a/testdata/wildfyfp.nv.json
+++ b/testdata/wildfyfp.nv.json
@@ -97,7 +97,7 @@
     },
     "match": {
       "label": "Match",
-      "value": 1
+      "value": "n/a"
     },
     "max_credits": {
       "label": "Max Credits",

--- a/testdata/wildfyre.nv.json
+++ b/testdata/wildfyre.nv.json
@@ -93,7 +93,7 @@
     },
     "match": {
       "label": "Match",
-      "value": 2
+      "value": "n/a"
     },
     "max_credits": {
       "label": "Max Credits",

--- a/testdata/wrlok_l3-default.nv.json
+++ b/testdata/wrlok_l3-default.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/wrlok_l3.nv.json
+++ b/testdata/wrlok_l3.nv.json
@@ -66,7 +66,7 @@
       },
       "19": {
         "label": "Pricing Control",
-        "value": 2
+        "value": "1/1DM, 3/2DM, 10/5DM"
       },
       "20": {
         "label": "Left Coin Slot Multiplier",
@@ -158,7 +158,7 @@
       },
       "99": {
         "label": "CMOS Checksum",
-        "value": 45733
+        "value": "valid"
       }
     },
     "Standard Audits": {

--- a/testdata/ww_lh6-default.nv.json
+++ b/testdata/ww_lh6-default.nv.json
@@ -557,7 +557,7 @@
     },
     "credits": {
       "label": "Credits",
-      "value": 255
+      "value": "FREE ONLY"
     },
     "current_ball": {
       "label": "Ball",

--- a/testdata/ww_lh6.nv.json
+++ b/testdata/ww_lh6.nv.json
@@ -557,7 +557,7 @@
     },
     "credits": {
       "label": "Credits",
-      "value": 255
+      "value": "FREE ONLY"
     },
     "current_ball": {
       "label": "Ball",

--- a/testdata/xsandosa.nv.json
+++ b/testdata/xsandosa.nv.json
@@ -10,15 +10,15 @@
     "High score functions": {
       "01": {
         "label": "Replay Level 1",
-        "value": 0
+        "value": "OFF"
       },
       "02": {
         "label": "Replay Level 2",
-        "value": 0
+        "value": "OFF"
       },
       "03": {
         "label": "Replay Level 3",
-        "value": 0
+        "value": "OFF"
       },
       "04": {
         "label": "High score to date",


### PR DESCRIPTION
These two descriptor properties were parsed into the model but ignored by the resolver:

- special_values: a {integer: label} map overriding the display of specific values (e.g. {"0": "OFF"}, {"256": "n/a"}). When the displayed value matches a key, resolve now returns the label and skips range validation.
- offset: a value added to a decoded int/bcd value after scale (e.g. the 1-based "Player Count" stored as count-1, or sentinels like 255+1 -> 256 -> "n/a").

The displayed integer (scale then offset) is what special_values matches, per the reference format and existing map usage.

Regenerate the affected testdata references (163 files): values covered by special_values now show their label, and offset fields show the adjusted value. Add unit tests for value_offset, special_value and number_from_i128.