### PR TITLE
test(resolve): ratchet on unexpected checksum mismatches

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -777,6 +777,104 @@ mod tests {
         Ok(())
     }
 
+    fn collect_checksum_mismatches(rom: &str, value: &Value, out: &mut Vec<String>) {
+        match value {
+            Value::Object(map) => {
+                if map.get("value").and_then(|v| v.as_str()) == Some("mismatch")
+                    && let (Some(exp), Some(calc)) = (
+                        map.get("checksum_mismatch_expected")
+                            .and_then(|v| v.as_u64()),
+                        map.get("checksum_mismatch_calculated")
+                            .and_then(|v| v.as_u64()),
+                    )
+                {
+                    let label = map
+                        .get("label")
+                        .and_then(|l| l.as_str())
+                        .unwrap_or("(no label)");
+                    out.push(format!(
+                        "{rom} | {label} | expected {exp:#x} calculated {calc:#x}"
+                    ));
+                }
+                for v in map.values() {
+                    collect_checksum_mismatches(rom, v, out);
+                }
+            }
+            Value::Array(array) => {
+                for v in array {
+                    collect_checksum_mismatches(rom, v, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Ratchet: the set of checksum mismatches the resolver reports must match
+    /// testdata/aaa_expected_checksum_mismatches.txt exactly, so a new mismatch
+    /// (a real regression or corrupt fixture) is caught and a fixed one must be
+    /// removed from the list deliberately. The directional message lists what to
+    /// add or remove.
+    #[test]
+    fn test_expected_checksum_mismatches() -> io::Result<()> {
+        let test_dir = testdir!();
+        let mut actual = Vec::new();
+        for entry in std::fs::read_dir("testdata")? {
+            let nvram_path = entry?.path();
+            if nvram_path.extension().and_then(|e| e.to_str()) != Some("nv") {
+                continue;
+            }
+            let rom = nvram_path
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string();
+            let path = path_for_test(&test_dir, &nvram_path)?;
+            if let Some(value) = resolve(&path)? {
+                collect_checksum_mismatches(&rom, &value, &mut actual);
+            }
+        }
+        let actual: std::collections::BTreeSet<String> = actual.into_iter().collect();
+
+        let expected_content =
+            std::fs::read_to_string("testdata/aaa_expected_checksum_mismatches.txt")?;
+        let expected: std::collections::BTreeSet<String> = expected_content
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty() && !l.starts_with('#'))
+            .map(|l| l.to_string())
+            .collect();
+
+        let new: Vec<&String> = actual.difference(&expected).collect();
+        let resolved: Vec<&String> = expected.difference(&actual).collect();
+
+        if !new.is_empty() || !resolved.is_empty() {
+            let mut msg = String::from(
+                "checksum mismatches differ from testdata/aaa_expected_checksum_mismatches.txt\n",
+            );
+            if !new.is_empty() {
+                msg.push_str(
+                    "\nNEW unexpected checksum mismatches - a regression to investigate, \
+                     or add these lines to the file if intended:\n",
+                );
+                for w in &new {
+                    msg.push_str(&format!("  + {w}\n"));
+                }
+            }
+            if !resolved.is_empty() {
+                msg.push_str(
+                    "\nExpected checksum mismatches that no longer occur - remove these lines \
+                     from the file:\n",
+                );
+                for w in &resolved {
+                    msg.push_str(&format!("  - {w}\n"));
+                }
+            }
+            panic!("{msg}");
+        }
+        Ok(())
+    }
+
     fn path_for_test(test_dir: &Path, nvram_path: &PathBuf) -> io::Result<PathBuf> {
         let path = if nvram_path
             .file_name()

--- a/testdata/aaa_expected_checksum_mismatches.txt
+++ b/testdata/aaa_expected_checksum_mismatches.txt
@@ -1,0 +1,58 @@
+# Expected checksum mismatches (the checksum ratchet, see test_expected_checksum_mismatches).
+#
+# Each "<rom> | <label> | expected <stored> calculated <computed>" line is a
+# checksum the resolver currently reports as a mismatch. The test fails if the
+# set of reported mismatches differs from this list, so a NEW mismatch (a real
+# regression - wrong offset/range/encoding, or a corrupt fixture) is caught, and
+# a fixed one must be removed from the list deliberately.
+#
+# KNOWN ISSUE: the ~30 System 11 "Credits" entries are FALSE mismatches caused by
+# the library not yet honoring the non-adjacent `checksum` field (v0.8). The
+# nvrams are valid (e.g. diner_l4: data 0x10 + checksum 0xef = 0xff). They will
+# be removed once checksum8/16 honor `checksum`.
+#
+# The remaining entries are genuinely uninitialised/unset regions (e.g. WPC
+# Volume never set: byte and its checksum both blank).
+#
+# Lines starting with '#' and blank lines are ignored.
+
+bbnny_l2 | Credits | expected 0x8 calculated 0xf6
+bcats_l5 | Credits | expected 0x8 calculated 0xf9
+bguns_l8 | Credits | expected 0x3 calculated 0x98
+bk2k_l4 | Credits | expected 0x5 calculated 0xf7
+bnzai_l3 | Credits | expected 0x4 calculated 0xfb
+bop_l8 | Volume | expected 0xffff calculated 0xff00
+cv_20h | Credits | expected 0xffff calculated 0xf807
+cycln_l5 | Credits | expected 0x3 calculated 0xfa
+dd_l2 | Credits | expected 0x6 calculated 0xf7
+diner_l4 | Credits | expected 0x8 calculated 0xef
+eatpm_l4 | Credits | expected 0x8 calculated 0xf7
+esha_l4c | Credits | expected 0x6 calculated 0xfc
+esha_la3 | Credits | expected 0x6 calculated 0xfa
+esha_ma3 | Credits | expected 0x6 calculated 0xf8
+f14_l1 | Credits | expected 0x4 calculated 0x9b
+fire_l3 | Credits | expected 0x4 calculated 0xb7
+ft_l5 | Audits | expected 0xf0 calculated 0xf1
+gs_la3 | Credits | expected 0x8 calculated 0xf8
+gs_lu4 | Credits | expected 0x8 calculated 0xd6
+hs_l4 | Credits | expected 0x4 calculated 0xd6
+jokrz_l6 | Credits | expected 0x5 calculated 0xcc
+mb_106 | Volume | expected 0xffff calculated 0xff00
+mousn_l4 | Credits | expected 0x8 calculated 0xef
+pb_l5 | Credits | expected 0x3 calculated 0xf9
+polic_l4 | Credits | expected 0x6 calculated 0xfc
+pool_l7 | Credits | expected 0x8 calculated 0xef
+radcl_l1 | Credits | expected 0x8 calculated 0xef
+rdkng_l4 | Credits | expected 0x3 calculated 0xee
+rollr_l2 | Credits | expected 0x9 calculated 0xf8
+spstn_l5 | Credits | expected 0x4 calculated 0xf8
+swrds_l2 | Credits | expected 0x5 calculated 0xed
+taf_h4 | Volume | expected 0xffff calculated 0xff00
+taf_l5 | Volume | expected 0xffff calculated 0xff00
+taxi_l4 | Credits | expected 0x4 calculated 0xf7
+tom_14h | Volume | expected 0xffff calculated 0xff00
+tsptr_l3 | Credits | expected 0x7 calculated 0xf9
+wd_12g | Volume | expected 0xffff calculated 0xff00
+whirl_l3 | Credits | expected 0x6 calculated 0xef
+ww_lh6 | Credits | expected 0xffff calculated 0xf906
+ww_lh6-default | Credits | expected 0xffff calculated 0xf906


### PR DESCRIPTION
Add test_expected_checksum_mismatches: it resolves every testdata nvram, collects the checksum results reported as "mismatch", and asserts the set matches testdata/aaa_expected_checksum_mismatches.txt. A new mismatch (a real regression or corrupt fixture) now fails the build, and a fixed one must be removed from the list deliberately; the failure message is directional.

Like test_resolve_all, this closes the gap where a checksum mismatch was only recorded in the golden .nv.json and never asserted (only nv_diner_l4 and nv_dm_lx4 checked checksums, and only checksum16).

Seed the list with the 40 current mismatches. ~30 of them are System 11 "Credits" entries that are FALSE mismatches: the library does not yet honor the non-adjacent `checksum` field (v0.8), so it reads the wrong byte (e.g. diner_l4 data 0x10 + checksum 0xef = 0xff is valid). Those are flagged in the file's header and will be removed once checksum8/16 honor `checksum`. The rest are genuinely uninitialised/unset regions (e.g. WPC Volume never set).