### PR TITLE
fix(checksum): honor the non-adjacent checksum8 `checksum` field

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -23,6 +23,35 @@ pub(crate) fn verify_checksum8<T: Read + Seek>(
     checksum8: &Checksum8,
 ) -> io::Result<Option<ChecksumMismatch<u8>>> {
     let start: u64 = (&checksum8.start).into();
+
+    // Non-adjacent checksum (file format v0.8): `start`..=`end` describe only the
+    // data bytes and the checksum is stored separately at `checksum`. Used for
+    // e.g. the single-byte Credits field on Williams System 11, whose checksum
+    // lives at an unrelated address.
+    if let Some(checksum_address) = checksum8.checksum {
+        let data_end: u64 = match &checksum8.end {
+            Some(e) => u64::from(e),
+            None => start + checksum8.length.unwrap_or(DEFAULT_LENGTH as u64) - 1,
+        };
+        let mut buff = vec![0; (data_end - start + 1) as usize];
+        read_exact_at(nvram_file, start, &mut buff)?;
+        let calc_sum: u8 = 0xFFu8 - buff.iter().fold(0u8, |acc, &x| acc.wrapping_add(x));
+
+        let mut checksum_byte = [0u8; 1];
+        read_exact_at(nvram_file, checksum_address, &mut checksum_byte)?;
+        let stored_sum = checksum_byte[0];
+
+        return if calc_sum != stored_sum {
+            Ok(Some(ChecksumMismatch {
+                label: Some(checksum8.label.clone()),
+                expected: stored_sum,
+                calculated: calc_sum,
+            }))
+        } else {
+            Ok(None)
+        };
+    }
+
     let end: u64 = match &checksum8.end {
         Some(e) => u64::from(e),
         None => {
@@ -276,6 +305,54 @@ mod test {
         };
         let result = verify_checksum8(&mut cursor, &checksum8);
         assert_eq!(None, result?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_checksum8_non_adjacent_checksum() -> io::Result<()> {
+        // data byte at 0 (0x10), unrelated bytes, checksum byte at 4 (0xEF).
+        // 0x10 + 0xEF == 0xFF -> valid (mirrors diner_l4 Credits).
+        #[rustfmt::skip]
+        let mut cursor = io::Cursor::new([
+            0x10, 0x00, 0x00, 0x00, 0xEF
+        ]);
+        let checksum8 = Checksum8 {
+            label: "Credits".to_string(),
+            start: HexOrInteger::Integer(0),
+            end: None,
+            length: None,
+            checksum: Some(4),
+            groupings: None,
+            _notes: None,
+        };
+        assert_eq!(None, verify_checksum8(&mut cursor, &checksum8)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_checksum8_non_adjacent_checksum_mismatch() -> io::Result<()> {
+        // data byte 0xFF with checksum byte 0xFF: 0xFF + 0xFF != 0xFF (blank slot)
+        #[rustfmt::skip]
+        let mut cursor = io::Cursor::new([
+            0xFF, 0x00, 0x00, 0x00, 0xFF
+        ]);
+        let checksum8 = Checksum8 {
+            label: "Credits".to_string(),
+            start: HexOrInteger::Integer(0),
+            end: None,
+            length: None,
+            checksum: Some(4),
+            groupings: None,
+            _notes: None,
+        };
+        assert_eq!(
+            Some(ChecksumMismatch {
+                label: Some("Credits".to_string()),
+                expected: 0xFF,
+                calculated: 0x00,
+            }),
+            verify_checksum8(&mut cursor, &checksum8)?
+        );
         Ok(())
     }
 

--- a/testdata/aaa_expected_checksum_mismatches.txt
+++ b/testdata/aaa_expected_checksum_mismatches.txt
@@ -6,53 +6,20 @@
 # regression - wrong offset/range/encoding, or a corrupt fixture) is caught, and
 # a fixed one must be removed from the list deliberately.
 #
-# KNOWN ISSUE: the ~30 System 11 "Credits" entries are FALSE mismatches caused by
-# the library not yet honoring the non-adjacent `checksum` field (v0.8). The
-# nvrams are valid (e.g. diner_l4: data 0x10 + checksum 0xef = 0xff). They will
-# be removed once checksum8/16 honor `checksum`.
-#
-# The remaining entries are genuinely uninitialised/unset regions (e.g. WPC
-# Volume never set: byte and its checksum both blank).
+# The remaining entries are genuinely uninitialised/unset regions: a value and
+# its checksum are both blank because that setting was never written (e.g. WPC
+# Volume never set -> byte 0xff with checksum 0xffff). ft_l5 Audits is an
+# off-by-one that still needs investigation.
 #
 # Lines starting with '#' and blank lines are ignored.
 
-bbnny_l2 | Credits | expected 0x8 calculated 0xf6
-bcats_l5 | Credits | expected 0x8 calculated 0xf9
-bguns_l8 | Credits | expected 0x3 calculated 0x98
-bk2k_l4 | Credits | expected 0x5 calculated 0xf7
-bnzai_l3 | Credits | expected 0x4 calculated 0xfb
 bop_l8 | Volume | expected 0xffff calculated 0xff00
 cv_20h | Credits | expected 0xffff calculated 0xf807
-cycln_l5 | Credits | expected 0x3 calculated 0xfa
-dd_l2 | Credits | expected 0x6 calculated 0xf7
-diner_l4 | Credits | expected 0x8 calculated 0xef
-eatpm_l4 | Credits | expected 0x8 calculated 0xf7
-esha_l4c | Credits | expected 0x6 calculated 0xfc
-esha_la3 | Credits | expected 0x6 calculated 0xfa
-esha_ma3 | Credits | expected 0x6 calculated 0xf8
-f14_l1 | Credits | expected 0x4 calculated 0x9b
-fire_l3 | Credits | expected 0x4 calculated 0xb7
 ft_l5 | Audits | expected 0xf0 calculated 0xf1
-gs_la3 | Credits | expected 0x8 calculated 0xf8
-gs_lu4 | Credits | expected 0x8 calculated 0xd6
-hs_l4 | Credits | expected 0x4 calculated 0xd6
-jokrz_l6 | Credits | expected 0x5 calculated 0xcc
 mb_106 | Volume | expected 0xffff calculated 0xff00
-mousn_l4 | Credits | expected 0x8 calculated 0xef
-pb_l5 | Credits | expected 0x3 calculated 0xf9
-polic_l4 | Credits | expected 0x6 calculated 0xfc
-pool_l7 | Credits | expected 0x8 calculated 0xef
-radcl_l1 | Credits | expected 0x8 calculated 0xef
-rdkng_l4 | Credits | expected 0x3 calculated 0xee
-rollr_l2 | Credits | expected 0x9 calculated 0xf8
-spstn_l5 | Credits | expected 0x4 calculated 0xf8
-swrds_l2 | Credits | expected 0x5 calculated 0xed
 taf_h4 | Volume | expected 0xffff calculated 0xff00
 taf_l5 | Volume | expected 0xffff calculated 0xff00
-taxi_l4 | Credits | expected 0x4 calculated 0xf7
 tom_14h | Volume | expected 0xffff calculated 0xff00
-tsptr_l3 | Credits | expected 0x7 calculated 0xf9
 wd_12g | Volume | expected 0xffff calculated 0xff00
-whirl_l3 | Credits | expected 0x6 calculated 0xef
 ww_lh6 | Credits | expected 0xffff calculated 0xf906
 ww_lh6-default | Credits | expected 0xffff calculated 0xf906

--- a/testdata/bbnny_l2.nv.json
+++ b/testdata/bbnny_l2.nv.json
@@ -198,10 +198,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 246,
-      "checksum_mismatch_expected": 8,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/bcats_l5.nv.json
+++ b/testdata/bcats_l5.nv.json
@@ -218,10 +218,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 249,
-      "checksum_mismatch_expected": 8,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/bguns_l8.nv.json
+++ b/testdata/bguns_l8.nv.json
@@ -162,10 +162,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 152,
-      "checksum_mismatch_expected": 3,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/bk2k_l4.nv.json
+++ b/testdata/bk2k_l4.nv.json
@@ -190,10 +190,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 247,
-      "checksum_mismatch_expected": 5,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/bnzai_l3.nv.json
+++ b/testdata/bnzai_l3.nv.json
@@ -166,10 +166,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 251,
-      "checksum_mismatch_expected": 4,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/cycln_l5.nv.json
+++ b/testdata/cycln_l5.nv.json
@@ -166,10 +166,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 250,
-      "checksum_mismatch_expected": 3,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/dd_l2.nv.json
+++ b/testdata/dd_l2.nv.json
@@ -202,10 +202,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 247,
-      "checksum_mismatch_expected": 6,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/diner_l4.nv.json
+++ b/testdata/diner_l4.nv.json
@@ -202,10 +202,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 239,
-      "checksum_mismatch_expected": 8,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/eatpm_l4.nv.json
+++ b/testdata/eatpm_l4.nv.json
@@ -190,10 +190,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 247,
-      "checksum_mismatch_expected": 8,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/esha_l4c.nv.json
+++ b/testdata/esha_l4c.nv.json
@@ -190,10 +190,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 252,
-      "checksum_mismatch_expected": 6,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/esha_la3.nv.json
+++ b/testdata/esha_la3.nv.json
@@ -190,10 +190,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 250,
-      "checksum_mismatch_expected": 6,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/esha_ma3.nv.json
+++ b/testdata/esha_ma3.nv.json
@@ -190,10 +190,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 248,
-      "checksum_mismatch_expected": 6,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/f14_l1.nv.json
+++ b/testdata/f14_l1.nv.json
@@ -142,10 +142,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 155,
-      "checksum_mismatch_expected": 4,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/fire_l3.nv.json
+++ b/testdata/fire_l3.nv.json
@@ -142,10 +142,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 183,
-      "checksum_mismatch_expected": 4,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/gs_la3.nv.json
+++ b/testdata/gs_la3.nv.json
@@ -198,10 +198,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 248,
-      "checksum_mismatch_expected": 8,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/gs_lu4.nv.json
+++ b/testdata/gs_lu4.nv.json
@@ -198,10 +198,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 214,
-      "checksum_mismatch_expected": 8,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/hs_l4.nv.json
+++ b/testdata/hs_l4.nv.json
@@ -394,10 +394,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 214,
-      "checksum_mismatch_expected": 4,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     },
     {
       "label": "Auto Replay Data",

--- a/testdata/jokrz_l6.nv.json
+++ b/testdata/jokrz_l6.nv.json
@@ -190,10 +190,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 204,
-      "checksum_mismatch_expected": 5,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/mousn_l4.nv.json
+++ b/testdata/mousn_l4.nv.json
@@ -198,10 +198,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 239,
-      "checksum_mismatch_expected": 8,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/pb_l5.nv.json
+++ b/testdata/pb_l5.nv.json
@@ -142,10 +142,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 249,
-      "checksum_mismatch_expected": 3,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/polic_l4.nv.json
+++ b/testdata/polic_l4.nv.json
@@ -198,10 +198,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 252,
-      "checksum_mismatch_expected": 6,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/pool_l7.nv.json
+++ b/testdata/pool_l7.nv.json
@@ -194,10 +194,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 239,
-      "checksum_mismatch_expected": 8,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     },
     {
       "label": "Audits Continued",

--- a/testdata/radcl_l1.nv.json
+++ b/testdata/radcl_l1.nv.json
@@ -198,10 +198,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 239,
-      "checksum_mismatch_expected": 8,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/rdkng_l4.nv.json
+++ b/testdata/rdkng_l4.nv.json
@@ -142,10 +142,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 238,
-      "checksum_mismatch_expected": 3,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/rollr_l2.nv.json
+++ b/testdata/rollr_l2.nv.json
@@ -194,10 +194,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 248,
-      "checksum_mismatch_expected": 9,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/spstn_l5.nv.json
+++ b/testdata/spstn_l5.nv.json
@@ -162,10 +162,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 248,
-      "checksum_mismatch_expected": 4,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/swrds_l2.nv.json
+++ b/testdata/swrds_l2.nv.json
@@ -166,10 +166,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 237,
-      "checksum_mismatch_expected": 5,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/taxi_l4.nv.json
+++ b/testdata/taxi_l4.nv.json
@@ -174,10 +174,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 247,
-      "checksum_mismatch_expected": 4,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/tsptr_l3.nv.json
+++ b/testdata/tsptr_l3.nv.json
@@ -435,10 +435,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 249,
-      "checksum_mismatch_expected": 7,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {

--- a/testdata/whirl_l3.nv.json
+++ b/testdata/whirl_l3.nv.json
@@ -202,10 +202,8 @@
       "value": "valid"
     },
     {
-      "checksum_mismatch_calculated": 239,
-      "checksum_mismatch_expected": 6,
       "label": "Credits",
-      "value": "mismatch"
+      "value": "valid"
     }
   ],
   "game_state": {


### PR DESCRIPTION
The v0.8 `checksum` property lets a checksum8 store its byte at an address unrelated to the data range (start..=end describe only the data). The library ignored it and instead popped the last byte of a start+length range, so every such descriptor false-mismatched.

This hit the single-byte Credits field on ~30 Williams System 11 games: e.g. diner_l4 has data 0x10 and checksum 0xef (0x10 + 0xef = 0xff, valid), but the library read 0x08 from the wrong address and reported a mismatch.

verify_checksum8 now sums the data bytes and compares against the byte at `checksum` when present. Regenerate the affected references (30 Credits flip mismatch -> valid) and drop them from aaa_expected_checksum_mismatches.txt. The remaining listed mismatches are genuinely uninitialised regions.

Add unit tests for the non-adjacent case (valid and mismatch).