### PR TITLE
refactor: update maps submodule to tomlogic/pinball-memory-maps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "pinmame-nvram-maps"]
-	path = pinmame-nvram-maps
-	url = https://github.com/tomlogic/pinmame-nvram-maps.git
+[submodule "pinball-memory-maps"]
+	path = pinball-memory-maps
+	url = https://github.com/tomlogic/pinball-memory-maps.git
 	update = merge

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ fn main() {
 
 ## Attributions
 
-This library makes use of the [PinMAME NVRAM Maps](https://github.com/tomlogic/pinmame-nvram-maps) project.
+This library makes use of the [Pinball Memory Maps](https://github.com/tomlogic/pinball-memory-maps) project.
 The maps are embedded in the library and are used to look up values in the nvram files.
 
 ## Development

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 fn main() -> io::Result<()> {
     // Directory containing JSON files
-    let json_dir = Path::new("pinmame-nvram-maps");
+    let json_dir = Path::new("pinball-memory-maps");
     println!("cargo:rerun-if-changed={}", json_dir.display());
 
     // Output directory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ impl Nvram {
     }
 
     /// Open a NVRAM file from the file system using the local maps
-    /// Expects the `pinmame-nvram-maps` folder to exist in the current working directory
+    /// Expects the `pinball-memory-maps` folder to exist in the current working directory
     ///
     /// # Returns
     ///
@@ -362,7 +362,7 @@ fn read_platform<T: DeserializeOwned>(platform_name: &str) -> io::Result<T> {
 
 fn read_platform_local<T: DeserializeOwned>(platform_name: &str) -> io::Result<T> {
     let platform_file_name = format!("{platform_name}.json");
-    let platform_path = Path::new("pinmame-nvram-maps")
+    let platform_path = Path::new("pinball-memory-maps")
         .join("platforms")
         .join(platform_file_name);
     if !platform_path.exists() {
@@ -394,7 +394,7 @@ fn find_map<T: DeserializeOwned>(rom_name: &String) -> io::Result<Option<T>> {
 }
 
 fn find_map_local<T: DeserializeOwned>(rom_name: &String) -> io::Result<Option<T>> {
-    let index_file = Path::new("pinmame-nvram-maps").join("index.json");
+    let index_file = Path::new("pinball-memory-maps").join("index.json");
     if !index_file.exists() {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
@@ -405,7 +405,7 @@ fn find_map_local<T: DeserializeOwned>(rom_name: &String) -> io::Result<Option<T
     let map: Value = serde_json::from_reader(index_file)?;
     match map.get(rom_name) {
         Some(map_path) => {
-            let map_file = Path::new("pinmame-nvram-maps").join(map_path.as_str().unwrap());
+            let map_file = Path::new("pinball-memory-maps").join(map_path.as_str().unwrap());
             if !map_file.exists() {
                 return Err(io::Error::new(
                     io::ErrorKind::NotFound,

--- a/src/model.rs
+++ b/src/model.rs
@@ -78,7 +78,7 @@ impl Platform {
 /// Descriptor for a single value in the NVRAM.
 /// Describing a section of the .nv file and how to interpret it
 ///
-/// see https://github.com/tomlogic/pinmame-nvram-maps?tab=readme-ov-file#descriptors
+/// see https://github.com/tomlogic/pinball-memory-maps?tab=readme-ov-file#descriptors
 #[derive(Serialize, Deserialize)]
 pub struct Descriptor {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -160,7 +160,7 @@ pub struct Checksum8 {
 #[derive(Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ValuesOrReference {
-    // TODO adjust both according to result of https://github.com/tomlogic/pinmame-nvram-maps/issues/83
+    // TODO adjust both according to result of https://github.com/tomlogic/pinball-memory-maps/issues/83
     Values(Vec<Value>),
     Reference(String),
 }
@@ -490,8 +490,8 @@ mod tests {
 
     #[test]
     fn read_all_nvram_maps() {
-        // read all ../pinmame-nvram-maps/*.json recursively
-        let maps_path = Path::new("pinmame-nvram-maps").join("maps");
+        // read all ../pinball-memory-maps/*.json recursively
+        let maps_path = Path::new("pinball-memory-maps").join("maps");
         let mut found_any = false;
         for entry in WalkDir::new(maps_path).into_iter().filter_map(|e| e.ok()) {
             let path = entry.path();
@@ -515,8 +515,8 @@ mod tests {
 
     #[test]
     fn read_all_platforms() {
-        // read all ../pinmame-nvram-maps/platforms/*.json recursively
-        let platforms_path = Path::new("pinmame-nvram-maps").join("platforms");
+        // read all ../pinball-memory-maps/platforms/*.json recursively
+        let platforms_path = Path::new("pinball-memory-maps").join("platforms");
         let mut found_any = false;
         for entry in WalkDir::new(platforms_path)
             .into_iter()

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -613,7 +613,7 @@ mod tests {
         let missing_nvrams_path = Path::new("testdata/aaa_missing_nvrams.txt");
         let missing_nvrams_content = std::fs::read_to_string(missing_nvrams_path)?;
 
-        let index = Path::new("pinmame-nvram-maps").join("index.json");
+        let index = Path::new("pinball-memory-maps").join("index.json");
         let testdata = Path::new("testdata");
         let index: Value = serde_json::from_str(&std::fs::read_to_string(index)?)?;
         let mut missing = Vec::new();

--- a/tests/nv_st_162h.rs
+++ b/tests/nv_st_162h.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 #[test]
 fn test_star_trek_stern() -> io::Result<()> {
     // TODO add test for st_161h.nv
-    // TODO fix last highscore value when this is implemented: https://github.com/tomlogic/pinmame-nvram-maps/issues/34
+    // TODO fix last highscore value when this is implemented: https://github.com/tomlogic/pinball-memory-maps/issues/34
     let mut nvram = Nvram::open(Path::new("testdata/st_162h.nv"))?.unwrap();
 
     let last_game = nvram.read_last_game()?;

--- a/tests/nv_ts_lx5.rs
+++ b/tests/nv_ts_lx5.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::path::Path;
 
 #[test]
-// see https://github.com/tomlogic/pinmame-nvram-maps/issues/27
+// see https://github.com/tomlogic/pinball-memory-maps/issues/27
 fn test_the_shadow_lx5() -> io::Result<()> {
     let mut nvram = Nvram::open(Path::new("testdata/ts_lx5.nv"))?.unwrap();
 


### PR DESCRIPTION
The upstream repository was renamed from pinmame-nvram-maps to pinball-memory-maps. Update the submodule URL, rename the local submodule folder, and update code paths and documentation links. The pinned commit is unchanged.

Note: open_local now looks for a pinball-memory-maps folder in the working directory instead of pinmame-nvram-maps; crate consumers are unaffected since published builds use the embedded maps.